### PR TITLE
Replace assert by check in a couple of places

### DIFF
--- a/src/server/common/CMakeLists.txt
+++ b/src/server/common/CMakeLists.txt
@@ -18,6 +18,9 @@ add_library(common_TimeStamp
             TimeStamp.h
             TimeStamp.cpp
            )
+target_link_libraries(common_TimeStamp
+                      common_logging
+                     )           
 cxx_test(common_TimeStampTest
          TimeStampTest.cpp
          common_TimeStamp 

--- a/src/server/common/TimeStamp.cpp
+++ b/src/server/common/TimeStamp.cpp
@@ -6,6 +6,7 @@
 #include "TimeStamp.h"
 #include <assert.h>
 #include <limits>
+#include <server/common/logging.h>
 
 namespace sail {
 
@@ -84,14 +85,14 @@ TimeStamp TimeStamp::makeUndefined() {
 
 
 bool TimeStamp::operator<(const TimeStamp &x) const {
-  assert(defined());
-  assert(x.defined());
+  CHECK(defined());
+  CHECK(x.defined());
   return _time < x._time;
 }
 
 double TimeStamp::difSeconds(const TimeStamp &a, const TimeStamp &b) {
-  assert(a.defined());
-  assert(b.defined());
+  CHECK(a.defined());
+  CHECK(b.defined());
   return (1.0/TimeRes)*double(a._time - b._time);
 }
 
@@ -104,10 +105,10 @@ TimeStamp operator-(const TimeStamp &a, const Duration<double> &b) {
 }
 
 TimeStamp operator+(const TimeStamp &a, const Duration<double> &b) {
-  assert(a.defined());
-  assert(!std::isnan(b.seconds()));
+  CHECK(a.defined());
+  CHECK(!std::isnan(b.seconds()));
   int64_t res = a._time + int64_t(TimeRes*b.seconds());
-  assert(res != UndefinedTime);
+  CHECK(res != UndefinedTime);
   return TimeStamp(res);
 }
 


### PR DESCRIPTION
As requested in a comment from the PR related to jo-parse, 'assert' could be replaced by 'CHECK' in the TimeStamp code. I have made this change in this PR.

However, I believe that assertions/exceptions/CHECK should mostly be seen as a complement to the test cases and in the released code they should not be triggered whenever they can be foreseen and avoided.
