### PR TITLE
Includes stdexcept

### DIFF
--- a/src/server/common/Hierarchy.cpp
+++ b/src/server/common/Hierarchy.cpp
@@ -3,10 +3,11 @@
  *      Author: Jonas Östlund <uppfinnarjonas@gmail.com>
  */
 
-#include  <sstream>
-#include "ArrayIO.h"
 #include "Hierarchy.h"
+
+#include <sstream>
 #include <assert.h>
+#include <server/common/ArrayIO.h>
 #include <server/common/logging.h>
 #include <server/common/string.h>
 #include <stdexcept>


### PR DESCRIPTION
Includes <stdexcept> to make sure runtime_error is defined.
Sort includes.
