### PR TITLE
Fix a testcase that fails on the digital ocean server

### DIFF
--- a/src/server/common/logging_test.cpp
+++ b/src/server/common/logging_test.cpp
@@ -59,6 +59,6 @@ TEST(LoggingTest, MainTest) {
                << d << ", "
                << s << ".";
 
-  EXPECT_NO_THROW(int *ptr = CHECK_NOTNULL(&a));
-  EXPECT_THROW(int *ptr2 = CHECK_NOTNULL(nullptr), internal::LogMessageException);
+  EXPECT_NO_THROW(CHECK_NOTNULL(&a));
+  EXPECT_THROW(CHECK_NOTNULL(nullptr), internal::LogMessageException);
 }


### PR DESCRIPTION
With these contributions, the logging_test passes when deployed on the server.
