### PR TITLE
Fix warning, simplify test.

### DIFF
--- a/src/server/common/string.cpp
+++ b/src/server/common/string.cpp
@@ -170,8 +170,8 @@ std::string int64ToHex(int64_t x) {
   std::string result(len, '0');
   for (int i = 0; i < sizeof(x); ++i) {
     int offs = 2*i;
-    result[offs + 0] = toHexDigit((x >> (15 - i) * 8 + 4) & 0xf);
-    result[offs + 1] = toHexDigit((x >> (15 - i) * 8 ) & 0xf);
+    result[offs + 0] = toHexDigit((x >> ((15 - i) * 8 + 4)) & 0xf);
+    result[offs + 1] = toHexDigit((x >> ((15 - i) * 8)) & 0xf);
   }
   return result;
 }

--- a/src/server/common/stringTest.cpp
+++ b/src/server/common/stringTest.cpp
@@ -35,12 +35,8 @@ TEST(StringTest, FormatTest) {
 }
 
 TEST(StringTest, Int64Test) {
-  int64_t x = 254;
-  constexpr int len = 2*sizeof(x);
-  std::string expected(len, '0');
-  expected[len-2] = 'F';
-  expected[len-1] = 'E';
-  EXPECT_EQ(expected, int64ToHex(x));
+  int64_t x = 0x1234567890ABCDEF;
+  EXPECT_EQ("1234567890ABCDEF", int64ToHex(x));
 }
 
 TEST(StringTest, Int64TestOrdering) {


### PR DESCRIPTION
Fix an operator precedence warning with llvm.
Simplify a test.
