### PR TITLE
Updated inclusion guard

### DIFF
--- a/src/server/common/logging.h
+++ b/src/server/common/logging.h
@@ -3,8 +3,8 @@
 \date 2012
 */
 
-#ifndef _LOGGING_H
-#define _LOGGING_H
+#ifndef _SERVER_COMMON_LOGGING_H
+#define _SERVER_COMMON_LOGGING_H
 
 #include <string>
 #include <sstream>


### PR DESCRIPTION
Changed the inclusion guard to avoid naming collision with google's logging library.
