### PR TITLE
Fix a bug when processing a single file.

### DIFF
--- a/src/server/nautical/BoatLogProcessor.cpp
+++ b/src/server/nautical/BoatLogProcessor.cpp
@@ -117,6 +117,9 @@ int BoatLogProcessor::main(const std::vector<std::string>& args) {
 
 void processBoatData(Nav::Id boatId, Array<Nav> navs, Poco::Path dstPath, std::string filenamePrefix) {
   ENTERSCOPE("processBoatData");
+  SCOPEDMESSAGE(INFO, stringFormat("Process %d navs ranging from %s to %s",
+      navs.size(), navs.first().time().toString().c_str(),
+      navs.last().time().toString().c_str()));
   Grammar001Settings settings;
   Grammar001 g(settings);
 
@@ -177,6 +180,7 @@ void processBoatDataSingleLogFile(Nav::Id boatId, Poco::Path srcPath, std::strin
   Array<Nav> navs = loadNavsFromNmea(srcfile.toString(),
       boatId).navs();
   SCOPEDMESSAGE(INFO, "done.");
+  std::sort(navs.begin(), navs.end());
   processBoatData(boatId, navs, dstPath, srcfile.getBaseName());
 }
 

--- a/src/server/nautical/grammars/Grammar001.cpp
+++ b/src/server/nautical/grammars/Grammar001.cpp
@@ -171,7 +171,6 @@ namespace {
         factors[index] = f*expectedData[index];
       }
     }
-    std::cout << EXPR_AND_VAL_AS_STRING(factors) << std::endl;
     return factors;
   }
 


### PR DESCRIPTION
This PR seems to address a bug of failing to parse a single file of NMEA data.

The program should not crash when it is called like below:

  xa4@anemolab:/home/jpilet/anemomind/build/src/server/nautical$ ./nautical_processBoatLogs /home/xa4/anemomind-web/data/532c4628c2587a084e3b52f0 29824-1udsnio.TXT
  [INFO /home/jpilet/anemomind/src/server/nautical/BoatLogProcessor.cpp:86] BEGIN: Anemomind boat log processor
  [INFO /home/jpilet/anemomind/src/server/nautical/BoatLogProcessor.cpp:97]   BEGIN: Process boat logs in directory /home/xa4/anemomind-web/data/532c4628c2587a084e3b52f0
  [INFO /home/jpilet/anemomind/src/server/nautical/BoatLogProcessor.cpp:172]     BEGIN: processBoatData single log file
  [INFO /home/jpilet/anemomind/src/server/nautical/BoatLogProcessor.cpp:173]       Loading data from boat with id 532c4628c2587a084e3b52f0
  [INFO /home/jpilet/anemomind/src/server/nautical/BoatLogProcessor.cpp:179]       done.
  [INFO /home/jpilet/anemomind/src/server/nautical/BoatLogProcessor.cpp:119]       BEGIN: processBoatData
  [INFO /home/jpilet/anemomind/src/server/nautical/BoatLogProcessor.cpp:123]         Parse data...
  factors = 
  Array with 24 elements:
  0.25 0 0.25 0.25 0 0.25 0 0.25 0.25 0.25 0.25 0 0.25 0.25 0 0 0.25 0.25 0.166667 0.166667 0.166667 0.166667 0.166667 0.166667 
  nautical_processBoatLogs: /home/jpilet/anemomind/src/server/nautical/grammars/Grammar001.cpp:140: double sail::{anonymous}::getG001StateTransitionCost(const sail::Grammar001Settings&, int, int, int, sail::Arraysail::Nav): Assertion `seconds >= 0.0' failed.
  Aborted
