### PR TITLE
Device simulator checks and bugfixes

### DIFF
--- a/src/device/Arduino/NMEAStats/NMEAStats.ino
+++ b/src/device/Arduino/NMEAStats/NMEAStats.ino
@@ -131,10 +131,10 @@ void displaySpeedRatio(const NmeaParser& parser) {
 
 void loadData() {
   ChunkTarget targets[] = {
-#ifdef VMG_TARGET_SPEED    
-    makeChunkTarget(&targetSpeedTable),
-#endif
     makeChunkTarget(&calibration)
+#ifdef VMG_TARGET_SPEED    
+    ,makeChunkTarget(&targetSpeedTable)
+#endif
   };
   
   ChunkLoader loader(targets, sizeof(targets) / sizeof(targets[0]));
@@ -150,7 +150,7 @@ void loadData() {
     }
   }
 
-  calibrationLoaded = targets[1].success;
+  calibrationLoaded = targets[0].success;
   
 #ifdef VMG_TARGET_SPEED
   if (!targets[0].success) {

--- a/src/device/Arduino/NMEAStats/test/DeviceSimulator.cpp
+++ b/src/device/Arduino/NMEAStats/test/DeviceSimulator.cpp
@@ -97,3 +97,16 @@ void DeviceSimulator::sendData(const std::string& data) {
     CHECK(Serial.available() == 0);
   }
 }
+
+bool DeviceSimulator::polarTableLoadedOrDisabled() const {
+#ifdef VMG_TARGET_SPEED
+  return true;
+#else
+  return !polarSpeedTable.empty();
+#endif
+}
+
+bool DeviceSimulator::calibrationFileLoaded() const {
+  return calibrationLoaded;
+}
+

--- a/src/device/Arduino/NMEAStats/test/DeviceSimulator.h
+++ b/src/device/Arduino/NMEAStats/test/DeviceSimulator.h
@@ -38,6 +38,13 @@ class DeviceSimulator {
   MockSD* SD();
 
   sail::TimeStamp getTimeStamp() const;
+
+  // Returns true if: VMG mode is enabled, or if the polar speed table
+  // has been properly loaded.
+  bool polarTableLoadedOrDisabled() const;
+
+  bool calibrationFileLoaded() const;
+
  private:
   long _arduinoTimeMs;
   sail::TimeStamp _referenceTime;

--- a/src/device/Arduino/NMEAStats/test/ScreenRecordingSimulator.cpp
+++ b/src/device/Arduino/NMEAStats/test/ScreenRecordingSimulator.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <server/common/string.h>
+#include <server/common/logging.h>
 
 namespace sail {
 
@@ -50,6 +51,15 @@ void ScreenRecordingSimulator::prepare(
   }
 
   setup();
+  if (boatDatFilename.size() > 0) {
+    CHECK(calibrationFileLoaded())
+      << "Failed to load " << boatDatFilename << " in the simulated device.";
+  }
+
+  if (polarDatFilename.size() > 0) {
+    CHECK(polarTableLoadedOrDisabled())
+      << "Failed to load " << polarDatFilename << " in the simulated device.";
+  }
 }
 
 void ScreenRecordingSimulator::simulate(std::string file) {


### PR DESCRIPTION
When running a simulator with  boat.dat and polar.dat files,
the simulator checks for proper loading.

Fixes a bug that was preventing proper usage of boat.dat
when compiled without VMG_TARGET_SPEED.
