### PR TITLE
Fix a 401 issue when trying to register.

### DIFF
--- a/www2/client/components/navbar/navbar.controller.js
+++ b/www2/client/components/navbar/navbar.controller.js
@@ -8,10 +8,19 @@ angular.module('www2App')
     }];
 
     $scope.boats = [];
-    $http.get('/api/boats')
-    .success(function(data, status, headers, config) {
-       $scope.boats = data;
-       socket.syncUpdates('boat', $scope.boats);
+
+    $scope.$watch('isLoggedIn', function(newval, oldval) {
+      if (newval != oldval) {
+        if (newval) {
+          $http.get('/api/boats')
+            .success(function(data, status, headers, config) {
+              $scope.boats = data;
+              socket.syncUpdates('boat', $scope.boats);
+            });
+        } else {
+          $scope.boats = [];
+        }
+      }
     });
 
     $scope.isCollapsed = true;


### PR DESCRIPTION
When registering, the page used to to access /api/boat before
beeing logged in. That was causing a 401 and an exception.

The menu now fetches the boat list only when logged in.
