### PR TITLE
Allow strings to be passed in the GET string

### DIFF
--- a/nodemodules/mail/json-coder.js
+++ b/nodemodules/mail/json-coder.js
@@ -44,12 +44,25 @@ function encodeArgs(argSpecs, args, trimmed) {
     }
 }
 
+// When passing strings as GET arguments,
+// just allow strings composed of common
+// characters that don't interfere with
+// the syntax of GET strings.
+function isValidGetString(x) {
+    return !!x.match(/^[\w]*$/)
+
+    // Maybe more specific: return !!x.match(/^[0-9a-zA-Z]*$/)
+}
+
 function encodeGetArg(argSpec, arg) {
     var type = schema.getArgType(argSpec);
     if (type == Boolean) {
 	return (arg? '1' : '0');
     } else if (type == Number) {
 	return '' + arg;
+    } else if (type == String) {
+	var res = isValidGetString(arg);
+	return arg;
     } else {
 	assert.equal(type, 'hex');
 	assert(bigint.isBigInt(arg));


### PR DESCRIPTION
I discovered that my previous PR, **jo-string-names** broke the **run-sync-http-demo.sh**. This PR fixes that.
