### PR TITLE
Adds a DispatcherFilter.

### DIFF
--- a/src/device/anemobox/CMakeLists.txt
+++ b/src/device/anemobox/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(anemobox_Dispatcher
             Dispatcher.h
             Dispatcher.cpp
             ValueDispatcher.h
+            FakeClockDispatcher.h
             )
 target_link_libraries(anemobox_Dispatcher
                       common_string
@@ -29,3 +30,17 @@ target_link_libraries(anemobox
                anemobox_Dispatcher
                anemobox_Nmea0183Source
               )
+
+add_library(anemobox_DispatcherFilter
+            DispatcherFilter.h
+            DispatcherFilter.cpp)
+target_link_libraries(anemobox_DispatcherFilter
+                      anemobox_Dispatcher
+                      common_TimeStamp
+                     )
+
+cxx_test(anemobox_DispatcherFilterTest DispatcherFilterTest.cpp
+         anemobox_Dispatcher
+         anemobox_DispatcherFilter
+         gtest_main
+        )

--- a/src/device/anemobox/Dispatcher.cpp
+++ b/src/device/anemobox/Dispatcher.cpp
@@ -5,18 +5,18 @@ namespace sail {
 Dispatcher *Dispatcher::_globalInstance = 0;
 
 Dispatcher::Dispatcher() :
-  _awa(&_data, AWA, "awa", "apparent wind angle"),
-  _aws(&_data, AWS, "aws", "apparent wind speed"),
-  _twa(&_data, TWA, "twa", "true wind angle"),
-  _tws(&_data, TWS, "tws", "true wind speed"),
-  _twdir(&_data, TWDIR, "twdir", "true wind direction"),
-  _gpsBearing(&_data, GPS_BEARING, "gpsBearing", "GPS bearing"),
-  _gpsSpeed(&_data, GPS_SPEED, "gpsSpeed", "GPS speed"),
-  _magHeading(&_data, MAG_HEADING, "magHdg", "magnetic heading"),
-  _watSpeed(&_data, WAT_SPEED, "watSpeed", "water speed"),
-  _watDist(&_data, WAT_DIST, "watDist", "distance over water"),
-  _pos(&_data, GPS_POS, "pos", "GPS position"),
-  _dateTime(&_data, DATE_TIME, "dateTime", "GPS date and time (UTC)")
+  _awa(&_data, AWA, "awa", "apparent wind angle", this),
+  _aws(&_data, AWS, "aws", "apparent wind speed", this),
+  _twa(&_data, TWA, "twa", "true wind angle", this),
+  _tws(&_data, TWS, "tws", "true wind speed", this),
+  _twdir(&_data, TWDIR, "twdir", "true wind direction", this),
+  _gpsBearing(&_data, GPS_BEARING, "gpsBearing", "GPS bearing", this),
+  _gpsSpeed(&_data, GPS_SPEED, "gpsSpeed", "GPS speed", this),
+  _magHeading(&_data, MAG_HEADING, "magHdg", "magnetic heading", this),
+  _watSpeed(&_data, WAT_SPEED, "watSpeed", "water speed", this),
+  _watDist(&_data, WAT_DIST, "watDist", "distance over water", this),
+  _pos(&_data, GPS_POS, "pos", "GPS position", this),
+  _dateTime(&_data, DATE_TIME, "dateTime", "GPS date and time (UTC)", this)
 {
 }
 

--- a/src/device/anemobox/Dispatcher.h
+++ b/src/device/anemobox/Dispatcher.h
@@ -64,9 +64,10 @@ class TypedDispatchData : public DispatchData {
   TypedDispatchData(std::map<DataCode, DispatchData*> *index,
                     DataCode nature,
                     std::string wordIdentifier,
-                    std::string description)
+                    std::string description,
+                    Clock* clock)
      : DispatchData(index, nature, wordIdentifier, description),
-     _dispatcher(1024) { }
+     _dispatcher(clock, 1024) { }
 
   virtual void visit(DispatchDataVisitor *visitor);
   ValueDispatcher<T> *dispatcher() { return &_dispatcher; }
@@ -103,7 +104,7 @@ void TypedDispatchData<T>::visit(DispatchDataVisitor *visitor) {
 
 //! Dispatcher: the hub for all values processed by the anemobox.
 // the data() method allows enumeration of all components.
-class Dispatcher {
+class Dispatcher : public Clock {
  public:
   Dispatcher();
 

--- a/src/device/anemobox/DispatcherFilter.cpp
+++ b/src/device/anemobox/DispatcherFilter.cpp
@@ -1,0 +1,59 @@
+#include <device/anemobox/DispatcherFilter.h>
+
+namespace sail {
+
+Angle<double> DispatcherFilter::filterAngle(
+    const DispatchAngleData *angles, Duration<> window) const {
+  HorizontalMotion<double> accumulator = HorizontalMotion<double>::zero();
+  double accumulatedWeight = 0;
+
+  TimeStamp now = _dispatcher->currentTime();
+
+  const std::deque<TimedValue<Angle<double>>>& angleValues =
+    angles->dispatcher()->values();
+
+  for (int i = 0; i < angleValues.size(); ++i) {
+    Duration<> delta = now - angleValues[i].time;
+    if (delta > window) {
+      break;
+    }
+    double factor = 1 - delta.seconds() / window.seconds(); 
+    accumulator = accumulator + HorizontalMotion<double>::polar(
+        Velocity<double>::knots(factor), angleValues[i].value);
+    accumulatedWeight += factor;
+  }
+
+  if (accumulatedWeight == 0) {
+    // TODO: return something invalid.
+    return Angle<>::degrees(0);
+  }
+  return accumulator.angle();
+}
+
+Velocity<double> DispatcherFilter::filterVelocity(
+    DispatchVelocityData *velocities, Duration<> window) const {
+  TimeStamp now = _dispatcher->currentTime();
+
+  const std::deque<TimedValue<Velocity<double>>>& velocityValues =
+    velocities->dispatcher()->values();
+  Velocity<double> velocityAccumulator = Velocity<double>::knots(0);
+
+  double velocityAccumulatedWeight = 0;
+  for (const TimedValue<Velocity<double>>& timedValue : velocityValues) {
+    Duration<> delta = now - timedValue.time;
+    if (delta > window) {
+      break;
+    }
+    double factor = 1 - delta.seconds() / window.seconds(); 
+    velocityAccumulator += timedValue.value.scaled(factor);
+    velocityAccumulatedWeight += factor;
+  }
+  if (velocityAccumulatedWeight == 0) {
+    // TODO: return something invalid.
+    return Velocity<>::knots(0);
+  }
+
+  return velocityAccumulator.scaled(1.0 / velocityAccumulatedWeight);
+}
+
+}  // namespace sail

--- a/src/device/anemobox/DispatcherFilter.h
+++ b/src/device/anemobox/DispatcherFilter.h
@@ -1,0 +1,70 @@
+#ifndef DEVICE_ANEMOBOX_FILTER_H
+#define DEVICE_ANEMOBOX_FILTER_H
+
+#include <device/Arduino/libraries/PhysicalQuantity/PhysicalQuantity.h>
+#include <device/anemobox/Dispatcher.h>
+#include <device/anemobox/ValueDispatcher.h>
+#include <server/common/TimeStamp.h>
+
+namespace sail {
+
+struct DispatcherFilterParams {
+  Duration<> apparentWindWindow;
+  Duration<> waterMotionWindow;
+  Duration<> gpsMotionWindow;
+
+  DispatcherFilterParams()
+    : apparentWindWindow(Duration<>::seconds(15)),
+    waterMotionWindow(Duration<>::seconds(10)),
+    gpsMotionWindow(Duration<>::seconds(3)) { }
+};
+
+// This class is in charge of applying a temporal filter on measured data.
+// It adapts the Dispatcher to functions such as computeTrueWind.
+class DispatcherFilter {
+ public:
+
+  // The dispatcher is expected to remain valid during
+  // the lifetime of the DispatcherFilter.
+  DispatcherFilter(Dispatcher* dispatcher,
+                   DispatcherFilterParams params) : _dispatcher(dispatcher) { }
+
+  Angle<> awa() const {
+    return filterAngle(_dispatcher->awa(), _params.apparentWindWindow);
+  }
+
+  Velocity<> aws() const {
+    return filterVelocity(_dispatcher->aws(), _params.apparentWindWindow);
+  }
+
+  Angle<> magHdg() const {
+    return filterAngle(_dispatcher->magHdg(), _params.waterMotionWindow);
+  }
+
+  Velocity<> watSpeed() const {
+    return filterVelocity(_dispatcher->watSpeed(), _params.waterMotionWindow);
+  }
+
+  Velocity<> gpsSpeed() const {
+    return filterVelocity(_dispatcher->gpsSpeed(), _params.gpsMotionWindow);
+  }
+
+  Angle<> gpsBearing() const {
+    return filterAngle(_dispatcher->gpsBearing(), _params.gpsMotionWindow);
+  }
+
+ private:
+
+  Angle<double> filterAngle(const DispatchAngleData *angles,
+                            Duration<> window) const;
+  Velocity<double> filterVelocity(DispatchVelocityData *velocities,
+                                  Duration<> window) const;
+
+  Dispatcher* _dispatcher;
+  DispatcherFilterParams _params;
+};
+
+}  // namespace sail
+
+#endif // DEVICE_ANEMOBOX_FILTER_H
+

--- a/src/device/anemobox/DispatcherFilterTest.cpp
+++ b/src/device/anemobox/DispatcherFilterTest.cpp
@@ -1,0 +1,64 @@
+#include <device/anemobox/DispatcherFilter.h>
+#include <device/anemobox/FakeClockDispatcher.h>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+using namespace sail;
+
+TEST(DispatcherFilterTest, singleValTest) {
+  FakeClockDispatcher dispatcher;
+
+  dispatcher.awa()->publishValue("test", Angle<double>::degrees(-3));
+  dispatcher.aws()->publishValue("test", Velocity<double>::knots(3));
+
+  DispatcherFilter filter(&dispatcher, DispatcherFilterParams());
+
+  double tolerance = 1e-5;
+  EXPECT_NEAR(-3, filter.awa().degrees(), tolerance);
+  EXPECT_NEAR(3, filter.aws().knots(), tolerance);
+}
+
+TEST(DispatcherFilterTest, changingValTest) {
+  FakeClockDispatcher dispatcher;
+  DispatcherFilter filter(&dispatcher, DispatcherFilterParams());
+
+  // 2 minutes with value A
+  for (int i = 0; i < 120; ++i) {
+    dispatcher.magHdg()->publishValue("test", Angle<double>::degrees(-3));
+    dispatcher.watSpeed()->publishValue("test", Velocity<double>::knots(3));
+    dispatcher.advance(Duration<>::seconds(1));
+  }
+
+  double tolerance = 1e-5;
+  EXPECT_NEAR(-3, filter.magHdg().degrees(), tolerance);
+  EXPECT_NEAR(3, filter.watSpeed().knots(), tolerance);
+
+  // 20 seconds with value B
+  for (int i = 0; i < 20; ++i) {
+    dispatcher.magHdg()->publishValue("test", Angle<double>::degrees(173));
+    dispatcher.watSpeed()->publishValue("test", Velocity<double>::knots(23));
+    dispatcher.advance(Duration<>::seconds(1));
+  }
+
+  // Value A should be filtered out.
+  EXPECT_NEAR(173, filter.magHdg().degrees(), tolerance);
+  EXPECT_NEAR(23, filter.watSpeed().knots(), tolerance);
+}
+
+TEST(DispatcherFilterTest, noisyValueTest) {
+  FakeClockDispatcher dispatcher;
+  DispatcherFilter filter(&dispatcher, DispatcherFilterParams());
+
+  // values with oscillations
+  for (int i = 0; i < 120; ++i) {
+    dispatcher.magHdg()->publishValue(
+        "test", Angle<double>::degrees(90 + sin(i * .7213) * 5));
+    dispatcher.watSpeed()->publishValue(
+        "test", Velocity<double>::knots(7 + sin(i * .343)));
+    dispatcher.advance(Duration<>::seconds(.1));
+  }
+
+  EXPECT_NEAR(90, filter.magHdg().degrees(), .5);
+  EXPECT_NEAR(7, filter.watSpeed().knots(), .1);
+}
+

--- a/src/device/anemobox/FakeClockDispatcher.h
+++ b/src/device/anemobox/FakeClockDispatcher.h
@@ -1,0 +1,21 @@
+#ifndef ANEMOBOX_FAKE_CLOCK_DISPATCHER_H
+#define ANEMOBOX_FAKE_CLOCK_DISPATCHER_H
+
+#include <device/anemobox/Dispatcher.h>
+
+namespace sail {
+
+class FakeClockDispatcher : public Dispatcher {
+ public:
+  FakeClockDispatcher() : _currentTime(TimeStamp::now()) { }
+  virtual TimeStamp currentTime() { return _currentTime; }
+
+  void setTime(TimeStamp time) { _currentTime = time; }
+  void advance(Duration<> delta) { _currentTime = _currentTime + delta; }
+ private:
+  TimeStamp _currentTime;
+};
+
+}  // namespace sail
+
+#endif  // ANEMOBOX_FAKE_CLOCK_DISPATCHER_H

--- a/src/device/anemobox/ValueDispatcher.h
+++ b/src/device/anemobox/ValueDispatcher.h
@@ -38,7 +38,7 @@ class Listener {
 
 template <typename T>
 struct TimedValue {
-  TimedValue(T value) : time(TimeStamp::now()), value(value) { }
+  TimedValue(TimeStamp time, T value) : time(time), value(value) { }
 
   TimeStamp time;
   T value;
@@ -47,7 +47,8 @@ struct TimedValue {
 template <typename T>
 class ValueDispatcher {
  public:
-  ValueDispatcher(int bufferLength) : bufferLength_(bufferLength) { }
+  ValueDispatcher(Clock* clock, int bufferLength)
+    : bufferLength_(bufferLength), clock(clock) { }
 
   void subscribe(Listener<T> *listener) { 
     listeners_.insert(listener);
@@ -67,6 +68,7 @@ class ValueDispatcher {
   std::set<Listener<T> *> listeners_;
   std::deque<TimedValue<T>> values_;
   size_t bufferLength_;
+  Clock* clock;
 };
 
 template <typename T>
@@ -103,7 +105,7 @@ void Listener<T>::stopListening() {
 
 template <typename T>
 void ValueDispatcher<T>::setValue(T value) {
-  values_.push_front(TimedValue<T>(value));
+  values_.push_front(TimedValue<T>(clock->currentTime(), value));
   while (values_.size() > bufferLength_) {
     values_.pop_back();
   }

--- a/src/device/anemobox/ValueDispatcherTest.cpp
+++ b/src/device/anemobox/ValueDispatcherTest.cpp
@@ -16,7 +16,8 @@ class MockListener : public Listener<int> {
 
 TEST(ValueDispatcherTest, Notify) {
   MockListener listener;
-  ValueDispatcher<int> dispatcher(1);
+  Clock clock;
+  ValueDispatcher<int> dispatcher(&clock, 1);
   dispatcher.subscribe(&listener);
 
   EXPECT_CALL(listener, gotValue(3));
@@ -29,7 +30,8 @@ TEST(ValueDispatcherTest, Notify) {
 }
 
 TEST(ValueDispatcher, AvoidFlooding) {
-  ValueDispatcher<int> dispatcher(1);
+  Clock clock;
+  ValueDispatcher<int> dispatcher(&clock, 1);
   MockListener listener(Duration<>::milliseconds(5));
   dispatcher.subscribe(&listener);
 

--- a/src/server/common/TimeStamp.h
+++ b/src/server/common/TimeStamp.h
@@ -76,6 +76,12 @@ TimeStamp operator+(const Duration<double> &a, const TimeStamp &b);
 
 std::ostream &operator<<(std::ostream &s, const TimeStamp &t);
 
+class Clock {
+ public:
+  virtual ~Clock() { }
+  virtual TimeStamp currentTime() { return TimeStamp::now(); }
+};
+
 } /* namespace sail */
 
 #endif /* TIMESTAMP_H_ */


### PR DESCRIPTION
Temporal filtering of dispatcher values.
The filter interface will make it possible to call:
TrueWindEstimator::computeTrueWind()

The dispatcher now has a virtual clock, to make it possible
to fake the clock (convenient for unit testing and for
faster than real-time replay)
