### PR TITLE
Suppress unnecessary message when receiving a log file on the server

### DIFF
--- a/www2/server/api/mailrpc/packet-callbacks.js
+++ b/www2/server/api/mailrpc/packet-callbacks.js
@@ -20,9 +20,6 @@ function makeLogFilenameFromParts(tgtDir, parsedFilename, counter) {
 function tryToSaveWithName(tgtDir, parsedFilename, counter, data, cb) {
   var filename = makeLogFilenameFromParts(tgtDir, parsedFilename, counter);
   fs.readFile(filename, function(err, loadedData) {
-    console.log("  -> err and data:");
-    console.log(err);
-    console.log(loadedData)
     if (err) { // <-- No such file with that name.
       fs.writeFile(filename, data, function(err) {
         console.log("Wrote log file: " + filename);


### PR DESCRIPTION
Remove these lines that I thought were due to a bug.
