### PR TITLE
generateAndUpload gracefully handles bad boat.dat

### DIFF
--- a/src/device/Arduino/NMEAStats/test/ScreenRecordingSimulator.cpp
+++ b/src/device/Arduino/NMEAStats/test/ScreenRecordingSimulator.cpp
@@ -39,7 +39,7 @@ bool ScreenRecordingSimulator::screenAt(TimeStamp time, ScreenInfo *result) {
   return true;
 }
 
-void ScreenRecordingSimulator::prepare(
+bool ScreenRecordingSimulator::prepare(
                 const std::string& boatDatFilename,
                 const std::string& polarDatFilename) {
   if (boatDatFilename.size() > 0) {
@@ -52,14 +52,19 @@ void ScreenRecordingSimulator::prepare(
 
   setup();
   if (boatDatFilename.size() > 0) {
-    CHECK(calibrationFileLoaded())
-      << "Failed to load " << boatDatFilename << " in the simulated device.";
+    if (!calibrationFileLoaded()) {
+	    return false;
+    }
+    //CHECK(calibrationFileLoaded())
+    //  << "Failed to load " << boatDatFilename << " in the simulated device.";
   }
 
   if (polarDatFilename.size() > 0) {
+	  return false;
     CHECK(polarTableLoadedOrDisabled())
       << "Failed to load " << polarDatFilename << " in the simulated device.";
   }
+  return true;
 }
 
 void ScreenRecordingSimulator::simulate(std::string file) {

--- a/src/device/Arduino/NMEAStats/test/ScreenRecordingSimulator.h
+++ b/src/device/Arduino/NMEAStats/test/ScreenRecordingSimulator.h
@@ -30,7 +30,7 @@ class ScreenRecordingSimulator : public DeviceSimulator {
 
   const std::vector<ScreenInfo> screenInfo() const { return _screenInfo; }
 
-  void prepare(const std::string& boatDatFilename,
+  bool prepare(const std::string& boatDatFilename,
                const std::string& polarDatFilename);
 
   void simulate(std::string filename);

--- a/src/server/nautical/tiles/generateAndUpload.cpp
+++ b/src/server/nautical/tiles/generateAndUpload.cpp
@@ -73,8 +73,9 @@ int main(int argc, const char** argv) {
   ScreenRecordingSimulator simulator;
   ScreenRecordingSimulator* simulatorPtr = 0;
   if (boatDat.size() > 0 || polarDat.size() > 0) {
-    simulator.prepare(boatDat, polarDat);
-    simulatorPtr = &simulator;
+    if (simulator.prepare(boatDat, polarDat)) {
+	    simulatorPtr = &simulator;
+    }
   }
   Array<Nav> rawNavs = scanNmeaFolder(navPath, boatId, simulatorPtr);
 

--- a/src/server/production/processNewLogs.sh
+++ b/src/server/production/processNewLogs.sh
@@ -9,33 +9,59 @@ LOG_DIR="/home/anemomind/userlogs/anemologs"
 PROCESSED_DIR="/home/anemomind/processed"
 
 # Make sure we have a ssh tunnel to anemolab DB
-ps aux | grep autossh | grep -q anemolab || (autossh -T -N -L 27017:localhost:27017 jpilet@anemolab.com &)
- 
+#ps aux | grep autossh | grep -q anemolab || (autossh -T -N -L 27017:localhost:27017 jpilet@anemolab.com &)
+killall ssh 2>&1 > /dev/null || true
+ssh -T -N -L 27017:localhost:27017 jpilet@anemolab.com &
+SSH_TUNNEL_PID=$!
+
+# wait for the tunnel to open.
+sleep 1
+
 for boatdir in "${LOG_DIR}/"*; do
   boat=$(basename "${boatdir}")
+  boatid=$(echo "${boat}" | sed 's/boat//')
   boatprocessdir="${PROCESSED_DIR}/${boat}"
   mkdir -p "${boatprocessdir}"
   lastprocess="${boatprocessdir}/lastprocess.md5"
 
   if [ -e "${lastprocess}" ] && ls -lR "${boatdir}" | md5sum | diff -q "${lastprocess}" - ; then
     # checksum OK, nothing to do.
-    echo "Skipping boat: ${boat}"
+    #echo "Skipping boat: ${boat}"
+    true
   else
     # checksum not present or not up to date: need recompute.
-    ls -lR "${boatdir}" | md5sum > "${lastprocess}"
+
+    boatdat="${boatprocessdir}/processed/boat.dat"
+    [ -f "${boatdat}" ] && rm -f "${boatdat}"
 
     # HACK: processBoatLogs can't deal with "log" files yet. Convert to NMEA first.
     "${BIN}"/logcat "${boatdir}"/*log > "${boatprocessdir}/LOG.TXT"
     if "${BIN}"/processBoatLogs "${boatprocessdir}" ; then
 
       # Upload the tiles to the database
-      "${BIN}"/tiles_generateAndUpload \
-        --boatDat "${boatprocessdir}/processed/boat.dat" \
-	--id $(echo "${boat}" | sed 's/boat//') \
+      if "${BIN}"/tiles_generateAndUpload \
+	--boatDat ${boatdat} \
+	--id ${boatid} \
 	--navpath "${boatprocessdir}" \
-	--table anemomind.tiles
+	--table anemomind.tiles \
+	--scale 20 ; then
+
+        # If a boat.dat file has been generated, mail it to the anemobox.
+	if [ -f "${boatdat}" ] ; then
+	  cat "${boatdat}" | ssh anemomind@anemolab.com NODE_ENV=production \
+            node /home/xa4/anemomind/www2/utilities/SendBoatData.js \
+            "${boatid}" /dev/stdin /home/anemobox/boat.dat
+        fi
+
+        # Recompute worked. Update the checksum.
+        ls -lR "${boatdir}" | md5sum > "${lastprocess}"
+      else
+        echo "tile_generateAndUpload FAILED for ${boatid}"
+      fi
     else
       echo "processBoatLogs FAILED for ${boatprocessdir}. Skipping upload."
     fi
   fi
 done
+
+kill $SSH_TUNNEL_PID


### PR DESCRIPTION
When there is not enough data to create a proper calibration in boat.dat,
generateAndUpload used to crash. Now, it simply ignores boat.dat.

Fix a few issues in processNewLogs.
