### PR TITLE
Disables BT. Integrates IMU. Optimizes GPS polling.

### DIFF
--- a/src/device/anemobox/anemonode/main.js
+++ b/src/device/anemobox/anemonode/main.js
@@ -8,10 +8,13 @@ var withLocalEndpoint = true;
 var withLogger = true;
 var withGps = true;
 var withSetTime = true;
-var withBT = true;
+var withBT = false;
 var echoGpsOnNmea = false;
 var withEstimator = true;
+var logInternalGpsNmea = false;
+var logExternalNmea = true;
 var withHttp = true;
+var withIMU = true;
 
 var config = require('./components/config');
 
@@ -46,7 +49,7 @@ if (withBT) {
 var nmea0183port = require('./components/nmea0183port');
 nmea0183port.init(nmea0183PortPath,
   function(data) { 
-  if (withLogger) {
+  if (withLogger && logExternalNmea) {
     logger.logText("NMEA0183 input", data.toString('ascii'));
   }
 });
@@ -65,7 +68,7 @@ require('./components/gps').init(
       if (echoGpsOnNmea) {
         nmea0183port.emitNmea0183Sentence(data);
       }
-      if (withLogger) {
+      if (withLogger && logInternalGpsNmea) {
         logger.logText("Internal GPS NMEA", data.toString('ascii'));
       }
     });
@@ -105,4 +108,11 @@ if (withEstimator) {
 
   estimator.loadCalib();
   estimator.start();
+}
+
+if (withIMU) {
+  var bno055 = require('./components/bno055.js');
+  bno055.init(function() {
+    bno055.setPublishInterval(100);
+  });
 }

--- a/src/device/anemobox/anemonode/package.json
+++ b/src/device/anemobox/anemonode/package.json
@@ -8,7 +8,7 @@
     "endpoint": "file:../../../../nodemodules/endpoint",
     "express": "^4.13.3",
     "mkdirp": "^0.5.0",
-    "mraa": "^0.6.2",
+    "mraa": "^0.7.0",
     "msgpack-js": "^0.3.0",
     "nan": "^1.7.0",
     "q": "^1.4.1",

--- a/src/device/anemobox/anemonode/test_gps.js
+++ b/src/device/anemobox/anemonode/test_gps.js
@@ -2,10 +2,10 @@ var anemonode = require('./build/Release/anemonode');
 
 // Internal GPS with output to NMEA0183
 require('./components/gps').init(function(buffer) {
-  //console.log(buffer.toString('ascii'));
+  console.log(buffer.toString('ascii'));
 });
 
 require('./components/settime.js');
-anemonode.dispatcher.dateTime.subscribe(function(val) {
+anemonode.dispatcher.values.dateTime.subscribe(function(val) {
   console.log('Got time: ' + val);
 });


### PR DESCRIPTION
Bluetooth is now disabled in main.js.
main.js now calls the bno055 code, sampling at 10Hz.
GPS reading time on I2C bus has been cut by 4: from >200ms to ~45ms.
This makes it possible to sample the IMU at about 10Hz.
Solves minor issues.
