### PR TITLE
Add support for partial session display

### DIFF
--- a/www2/client/app/vectormap/tiles/VectorTileLayer.js
+++ b/www2/client/app/vectormap/tiles/VectorTileLayer.js
@@ -155,7 +155,7 @@ VectorTileLayer.prototype.requestTile = function(scale, tileX, tileY,
   }
 };
 
-// If selectedCurve does not matches exactly the start and end times of a
+// If selectedCurve does not match exactly the start and end times of a
 // recorded session, we still want to display part of it.
 // This function returns true if both curve times overlap.
 function curveOverlap(a, b) {


### PR DESCRIPTION
It is now possible to select a curve with start and end times
that do not match exactly a session.
