### PR TITLE
Support older browsers (again)

### DIFF
--- a/www2/Gruntfile.js
+++ b/www2/Gruntfile.js
@@ -247,18 +247,8 @@ module.exports = function (grunt) {
       options: {
         dest: '<%= yeoman.dist %>/public',
         flow: {
-          steps: { js: ['concat', 'uglifyjs'], css: ['concat', 'cssmin'] },
-          post: {
-            css: [{
-              name: 'cssmin',
-              createConfig: function (context, block) {
-                var generated = context.options.generated;
-                generated.options = {
-                  aggressiveMerging: false
-                };
-              }
-            }]
-          }
+          steps: { js: ['concat', 'uglifyjs'], css: ['concat'] },
+          post: { }
         }
       }
     },
@@ -638,7 +628,6 @@ module.exports = function (grunt) {
     'ngAnnotate',
     'copy:dist',
     'cdnify',
-    'cssmin',
     'uglify',
     'rev',
     'usemin'

--- a/www2/client/app/map/map.css
+++ b/www2/client/app/map/map.css
@@ -95,11 +95,11 @@ perfplot {
   overflow: auto;
 }
 
-.mapScreenContainer footer {
+.responsiveNavButtons {
   display: flex;
   flex-direction: row;
 }
-.mapScreenContainer footer button {
+.flexOne {
   flex: 1;
 }
 

--- a/www2/client/app/map/map.html
+++ b/www2/client/app/map/map.html
@@ -75,17 +75,17 @@
     </sidebar>
   </div>
 
-  <footer
+  <footer class="responsiveNavButtons"
     ><button type="button" ng-hide="mapActive"
-        class="btn btn-default btn-sm"
+        class="flexOne btn btn-default btn-sm"
         ng-click="activateMap()"
       ><i class="fa fa-map"></i></button
     ><button type="button" ng-hide="graphActive"
-        class="btn btn-default btn-sm"
+        class="flexOne btn btn-default btn-sm"
         ng-click="activateGraph()"
       ><i class="fa fa-area-chart"></i></button
     ><button type="button" ng-hide="sideBarActive"
-        class="btn btn-default btn-sm"
+        class="flexOne btn btn-default btn-sm"
         ng-click="activateSideBar()"
       ><i class="fa fa-tachometer"></i></button
   ></footer>

--- a/www2/package.json
+++ b/www2/package.json
@@ -6,6 +6,7 @@
     "async": "^0.9.0",
     "balanced-match": "^0.2.0",
     "body-parser": "~1.5.0",
+    "clean-css": "^3.4.6",
     "composable-middleware": "^0.3.0",
     "compression": "~1.0.1",
     "concat-map": "0.0.1",


### PR DESCRIPTION
On iOS 8.2, the map was broken. This pull request removes clean-css completely.
The css files are now slightly larger, but at least, they work.
