### PR TITLE
Add BinaryConstraintGroup for special case of two constraints

### DIFF
--- a/src/server/math/irls.cpp
+++ b/src/server/math/irls.cpp
@@ -195,7 +195,6 @@ void ConstraintGroup::apply(
   Arrayd weights = distributeWeights(
       thresholdedResiduals,
       constraintWeight);
-
   int n = weights.size();
   assert(n == _spans.size());
   assert(n == residualsPerConstraint.size());
@@ -205,6 +204,23 @@ void ConstraintGroup::apply(
     for (auto j : span) {
       dst->setWeight(j, w);
     }
+  }
+}
+
+void BinaryConstraintGroup::apply(double constraintWeight,
+    const Arrayd &residuals, QuadCompiler *dst) {
+  auto totalCstWeight = 2.0*constraintWeight;
+  auto ra = calcResidualForSpan(_a, residuals);
+  auto rb = calcResidualForSpan(_b, residuals);
+  auto aw = toFinite(rb/(ra + rb), 0.5);
+  auto bw = 1.0 - aw;
+  auto awc = totalCstWeight*aw;
+  auto bwc = totalCstWeight*bw;
+  for (auto i : _a) {
+    dst->setWeight(i, awc);
+  }
+  for (auto i : _b) {
+    dst->setWeight(i, bwc);
   }
 }
 

--- a/src/server/math/irls.h
+++ b/src/server/math/irls.h
@@ -148,12 +148,25 @@ class ConstraintGroup : public WeightingStrategy {
   static WeightingStrategy::Ptr make(Array<Spani> spans, int activeCount);
 
   void apply(
-      double constraintWeight,
-      const Arrayd &residuals, QuadCompiler *dst);
+        double constraintWeight,
+        const Arrayd &residuals, QuadCompiler *dst);
  private:
   Array<Spani> _spans;
   int _activeCount;
   double _minResidual;
+};
+
+// Like ConstraintGroup, but for the special case
+// of two spans among which one should be active.
+class BinaryConstraintGroup : public WeightingStrategy {
+ public:
+  BinaryConstraintGroup() {}
+  BinaryConstraintGroup(const Spani &a, const Spani &b) : _a(a), _b(b) {}
+
+  void apply(double constraintWeight,
+      const Arrayd &residuals, QuadCompiler *dst);
+ private:
+  Spani _a, _b;
 };
 
 class NonNegativeConstraint : public WeightingStrategy {

--- a/src/server/math/irlsTest.cpp
+++ b/src/server/math/irlsTest.cpp
@@ -35,6 +35,24 @@ TEST(IrlsTest, DistributeWeights) {
   EXPECT_LT(W1[1], W1[0] + smallGap);
 }
 
+TEST(IrlsTest, ConstraintGroup) {
+  Spani a(0, 2);
+  Spani b(2, 3);
+  Arrayd residuals{3, 4, 9.8};
+  double cstWeight = 15;
+  irls::ConstraintGroup generalGroup(Array<Spani>{a, b}, 1);
+  irls::BinaryConstraintGroup binaryGroup(a, b);
+  irls::QuadCompiler gComp(3), bComp(3);
+  generalGroup.apply(cstWeight, residuals, &gComp);
+  binaryGroup.apply(cstWeight, residuals, &bComp);
+  auto generalResults = gComp.makeWeightsAndOffset();
+  auto binaryResults = bComp.makeWeightsAndOffset();
+  for (int i = 0; i < 3; i++) {
+    EXPECT_NEAR(generalResults.weights.diagonal()(i), binaryResults.weights.diagonal()(i), 1.0e-9);
+
+  }
+}
+
 TEST(IrlsTest, SignalFit) {
   // Fit a line to a signal subject to sparsity constraints.
   // We allow for exactly two discontinuities in the fitted signal.

--- a/src/server/math/nonlinear/DataFit.cpp
+++ b/src/server/math/nonlinear/DataFit.cpp
@@ -55,7 +55,7 @@ irls::WeightingStrategy::Ptr makeThresholdedInlierFilter(double threshold,
   assert(outlierSlackRows.dim() == 1);
   assert(outlierPenaltyRows.sameSizeAs(outlierSlackRows));
 
-  Array<irls::ConstraintGroup> groups(count);
+  Array<irls::BinaryConstraintGroup> groups(count);
   for (int i = 0; i < count; i++) {
     auto rowSpan = dataRows.span(i);
     auto inlierRowSpan = inlierSlackRows.span(i);
@@ -66,12 +66,12 @@ irls::WeightingStrategy::Ptr makeThresholdedInlierFilter(double threshold,
     makeEye(1.0, inlierSlackRows.span(i), inlierCols.span(i), aDst);
     (*bDst)(outlierPenaltyRows[i]) = threshold;
     (*bDst)(outlierSlackRows[i]) = 0;
-    groups[i] = irls::ConstraintGroup(
-        Array<Spani>{inlierSlackRows.span(i), outlierSlackRows.span(i)}, 1);
+    groups[i] = irls::BinaryConstraintGroup(
+        inlierSlackRows.span(i), outlierSlackRows.span(i));
   }
   makeEye(1.0, outlierPenaltyRows.elementSpan(), outlierCols.elementSpan(), aDst);
   makeEye(1.0, outlierSlackRows.elementSpan(), outlierCols.elementSpan(), aDst);
-  return irls::WeightingStrategyArray<irls::ConstraintGroup>::make(groups);
+  return irls::WeightingStrategyArray<irls::BinaryConstraintGroup>::make(groups);
 }
 
 


### PR DESCRIPTION
The BinaryConstraintGroup works like ConstraintGroup, but for the special case of only two constraints among which one should be active. With this change, the mathematics is a lot easier and we also gain a speedup. The time for running GpsFilterTest in release mode is reduced from 1.7 seconds to 0.7 seconds.
