### PR TITLE
Read optional integers from BitStream

### DIFF
--- a/src/device/anemobox/n2k/BitStream.cpp
+++ b/src/device/anemobox/n2k/BitStream.cpp
@@ -9,16 +9,22 @@ bool BitStream::canRead(int numBits) const {
   return (bitPos_ + numBits) <= (lenBytes_ * 8);
 }
 
-bool BitStream::isAvailable(int64_t x, int numBits) {
-  assert(false);
-  auto maxv = static_cast<int64_t>(BitStreamInternals::getMaxSignedValueTwosComplement(numBits));
-  return x != maxv;
+Optional<int64_t> BitStream::getOptionalSigned(int numBits, int64_t offset) {
+  auto x = getSigned(numBits, offset);
+  if (x == BitStreamInternals::getMaxSignedValue(numBits, offset)) {
+    return Optional<int64_t>();
+  }
+  return Optional<int64_t>(x);
 }
 
-bool BitStream::isAvailable(uint64_t x, int numBits) {
-  auto maxv = BitStreamInternals::getMaxUnsignedValue(numBits);
-  return x != maxv;
+Optional<uint64_t> BitStream::getOptionalUnsigned(int numBits) {
+  auto x = getUnsigned(numBits);
+  if (x == BitStreamInternals::getMaxUnsignedValue(numBits)) {
+    return Optional<uint64_t>();
+  }
+  return Optional<uint64_t>(x);
 }
+
 
 uint64_t BitStream::getUnsigned(int numBits) {
   assert(numBits > 0 && numBits <= 64);
@@ -55,6 +61,13 @@ namespace BitStreamInternals {
   // not needed, but included for the sake of completeness.
   uint64_t getMaxSignedValueTwosComplement(int numBits) {
     return getMaxUnsignedValue(numBits) >> 1;
+  }
+
+  uint64_t getMaxSignedValue(int numBits, int64_t offset) {
+    if (offset == 0) {
+      return getMaxSignedValueTwosComplement(numBits);
+    }
+    return static_cast<int64_t>(getMaxUnsignedValue(numBits)) + offset;
   }
 }
 

--- a/src/device/anemobox/n2k/BitStream.h
+++ b/src/device/anemobox/n2k/BitStream.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <algorithm>
+#include <server/common/Optional.h>
 
 /* Read a packed stream of arbirarily sized ints, not necessarily aligned on
  * bytes.
@@ -43,9 +44,10 @@ class BitStream {
     return lengthBits() - bitPos_;
   }
 
-  static bool isAvailable(int64_t x, int numBits);
-  static bool isAvailable(uint64_t x, int numBits);
-
+  // If the raw integer read equals the maximum possible value
+  // of the encoding, it is assumed to be undefined.
+  Optional<int64_t> getOptionalSigned(int numBits, int64_t offset = 0);
+  Optional<uint64_t> getOptionalUnsigned(int numBits);
  private:
   uint8_t readBitsInByte(int wantedNumBits, uint8_t*bits) {
     int remainingBitsInThisByte = 8 - bitOffset();
@@ -70,6 +72,7 @@ namespace BitStreamInternals {
   // For example, if have 6 bits, this function should return 2^6-1, which is 63
   uint64_t getMaxUnsignedValue(int numBits);
   uint64_t getMaxSignedValueTwosComplement(int numBits);
+  uint64_t getMaxSignedValue(int numBits, int64_t offset);
 }
 
 #endif  // BITSTREAM_H

--- a/src/device/anemobox/n2k/BitStreamTest.cpp
+++ b/src/device/anemobox/n2k/BitStreamTest.cpp
@@ -176,6 +176,7 @@ TEST(BitStreamTest, Signed_negative_7_with_offset) {
     int bits = 6;
 
     auto streamValue = stream.getSigned(bits, offset);
+    EXPECT_EQ(63 + offset, BitStreamInternals::getMaxSignedValue(6, offset));
     EXPECT_EQ(-7, streamValue);
   }
 }
@@ -186,6 +187,8 @@ TEST(BitStreamTest, Max_value_at_the_limit) {
   uint64_t expectedSignedMax = expectedUnsignedMax >> 1;
   EXPECT_EQ(expectedUnsignedMax, BitStreamInternals::getMaxUnsignedValue(limit));
   EXPECT_EQ(expectedSignedMax, BitStreamInternals::getMaxSignedValueTwosComplement(limit));
+  EXPECT_EQ(expectedSignedMax, BitStreamInternals::getMaxSignedValue(limit, 0));
+  EXPECT_EQ(expectedUnsignedMax - 3, BitStreamInternals::getMaxSignedValue(limit, -3));
 }
 
 // Based on the Windows NK2 application connected to

--- a/src/device/anemobox/n2k/PgnClasses.cpp
+++ b/src/device/anemobox/n2k/PgnClasses.cpp
@@ -1,4 +1,4 @@
-/** Generated on Thu Jan 21 2016 20:15:44 GMT+0100 (CET) using 
+/** Generated on Thu Jan 21 2016 20:41:35 GMT+0100 (CET) using 
  *
  *     node /home/jonas/programmering/sailsmart/src/device/anemobox/n2k/codegen/index.js /home/jonas/programmering/cpp/canboat/analyzer/pgns.xml
  *
@@ -17,12 +17,17 @@ namespace PgnClasses {
   VesselHeading::VesselHeading(const uint8_t *data, int lengthBytes) {
     BitStream src(data, lengthBytes);
     if (58 <= src.remainingBits()) {
-      {auto x = src.getUnsigned(8); if (BitStream::isAvailable(x, 8)) {_sid = x;}}
-      {auto x = src.getUnsigned(16); if (BitStream::isAvailable(x, 16)) {_heading = double(0.0001*x)*sail::Angle<double>::radians(1.0);}}
-      {auto x = src.getSigned(16); if (BitStream::isAvailable(x, 16)) {_deviation = double(0.0001*x)*sail::Angle<double>::radians(1.0);}}
-      {auto x = src.getSigned(16); if (BitStream::isAvailable(x, 16)) {_variation = double(0.0001*x)*sail::Angle<double>::radians(1.0);}}
-      {auto x = src.getUnsigned(2); if (BitStream::isAvailable(x, 2)) {_reference = x;}}
-
+      _sid = src.getOptionalUnsigned(8);
+      src.getOptionalUnsigned(16).then([&](uint64_t x) {
+        _heading = (0.0001*x)*sail::Angle<double>::radians(1.0);
+      });
+      src.getOptionalSigned(16).then([&](int64_t x) {
+        _deviation = (0.0001*x)*sail::Angle<double>::radians(1.0);
+      });
+      src.getOptionalSigned(16).then([&](int64_t x) {
+        _variation = (0.0001*x)*sail::Angle<double>::radians(1.0);
+      });
+      _reference = src.getOptionalUnsigned(2);
       _valid = true;
     } else {
       reset();
@@ -40,8 +45,7 @@ namespace PgnClasses {
   Attitude::Attitude(const uint8_t *data, int lengthBytes) {
     BitStream src(data, lengthBytes);
     if (56 <= src.remainingBits()) {
-      {auto x = src.getUnsigned(8); if (BitStream::isAvailable(x, 8)) {_sid = x;}}
-      // Skipping yaw
+      _sid = src.getOptionalUnsigned(8);      // Skipping yaw
       src.advanceBits(16);
       // Skipping pitch
       src.advanceBits(16);
@@ -65,11 +69,14 @@ namespace PgnClasses {
   Speed::Speed(const uint8_t *data, int lengthBytes) {
     BitStream src(data, lengthBytes);
     if (44 <= src.remainingBits()) {
-      {auto x = src.getUnsigned(8); if (BitStream::isAvailable(x, 8)) {_sid = x;}}
-      {auto x = src.getUnsigned(16); if (BitStream::isAvailable(x, 16)) {_speedWaterReferenced = double(0.01*x)*sail::Velocity<double>::metersPerSecond(1.0);}}
-      {auto x = src.getUnsigned(16); if (BitStream::isAvailable(x, 16)) {_speedGroundReferenced = double(0.01*x)*sail::Velocity<double>::metersPerSecond(1.0);}}
-      {auto x = src.getUnsigned(4); if (BitStream::isAvailable(x, 4)) {_speedWaterReferencedType = x;}}
-
+      _sid = src.getOptionalUnsigned(8);
+      src.getOptionalUnsigned(16).then([&](uint64_t x) {
+        _speedWaterReferenced = (0.01*x)*sail::Velocity<double>::metersPerSecond(1.0);
+      });
+      src.getOptionalUnsigned(16).then([&](uint64_t x) {
+        _speedGroundReferenced = (0.01*x)*sail::Velocity<double>::metersPerSecond(1.0);
+      });
+      _speedWaterReferencedType = src.getOptionalUnsigned(4);
       _valid = true;
     } else {
       reset();
@@ -87,11 +94,14 @@ namespace PgnClasses {
   WindData::WindData(const uint8_t *data, int lengthBytes) {
     BitStream src(data, lengthBytes);
     if (43 <= src.remainingBits()) {
-      {auto x = src.getUnsigned(8); if (BitStream::isAvailable(x, 8)) {_sid = x;}}
-      {auto x = src.getUnsigned(16); if (BitStream::isAvailable(x, 16)) {_windSpeed = double(0.01*x)*sail::Velocity<double>::metersPerSecond(1.0);}}
-      {auto x = src.getUnsigned(16); if (BitStream::isAvailable(x, 16)) {_windAngle = double(0.0001*x)*sail::Angle<double>::radians(1.0);}}
-      {auto x = src.getUnsigned(3); if (BitStream::isAvailable(x, 3)) {_reference = x;}}
-
+      _sid = src.getOptionalUnsigned(8);
+      src.getOptionalUnsigned(16).then([&](uint64_t x) {
+        _windSpeed = (0.01*x)*sail::Velocity<double>::metersPerSecond(1.0);
+      });
+      src.getOptionalUnsigned(16).then([&](uint64_t x) {
+        _windAngle = (0.0001*x)*sail::Angle<double>::radians(1.0);
+      });
+      _reference = src.getOptionalUnsigned(3);
       _valid = true;
     } else {
       reset();

--- a/src/device/anemobox/n2k/PgnClasses.h
+++ b/src/device/anemobox/n2k/PgnClasses.h
@@ -1,4 +1,4 @@
-/** Generated on Thu Jan 21 2016 20:15:44 GMT+0100 (CET) using 
+/** Generated on Thu Jan 21 2016 20:41:35 GMT+0100 (CET) using 
  *
  *     node /home/jonas/programmering/sailsmart/src/device/anemobox/n2k/codegen/index.js /home/jonas/programmering/cpp/canboat/analyzer/pgns.xml
  *

--- a/src/server/common/Optional.h
+++ b/src/server/common/Optional.h
@@ -86,6 +86,12 @@ class Optional {
     }
     return true;
   }
+
+  void then(std::function<void(T)> todo) const {
+    if (_defined) {
+      todo(_value);
+    }
+  }
  private:
   bool _defined;
   T _value;


### PR DESCRIPTION
I think the code here deals with reading optional integers from BitStream in a nicer way. So instead of generating an if-statement to check if the integer just read is available, we add methods to BitStream that returns optionals directly.
