### PR TITLE
Deal with enum'ed values when parsing NMEA2000 data

### DIFF
--- a/src/device/anemobox/n2k/N2kField.h
+++ b/src/device/anemobox/n2k/N2kField.h
@@ -24,14 +24,6 @@ enum class Definedness {
 uint64_t getMaxUnsignedValue(int numBits);
 uint64_t getMaxSignedValue(int numBits, int64_t offset);
 
-template <typename T>
-Optional<T> castIntegerToOptional(Optional<uint64_t> x) {
-  if (x.defined()) {
-    return Optional<T>(static_cast<T>(x()));
-  }
-  return Optional<T>();
-}
-
 class N2kFieldStream : public BitStream {
  public:
   N2kFieldStream(const uint8_t *data, int lengthBytes) : BitStream(data, lengthBytes) {}

--- a/src/device/anemobox/n2k/PgnClasses.cpp
+++ b/src/device/anemobox/n2k/PgnClasses.cpp
@@ -1,4 +1,4 @@
-/** Generated on Fri Jan 22 2016 14:54:17 GMT+0100 (CET) using 
+/** Generated on Fri Jan 22 2016 15:06:52 GMT+0100 (CET) using 
  *
  *     node /home/jonas/programmering/sailsmart/src/device/anemobox/n2k/codegen/index.js /home/jonas/programmering/cpp/canboat/analyzer/pgns.xml
  *
@@ -21,7 +21,7 @@ namespace PgnClasses {
       _heading = src.getPhysicalQuantity(false, 0.0001, sail::Angle<double>::radians(1.0), 16, 0);
       _deviation = src.getPhysicalQuantity(true, 0.0001, sail::Angle<double>::radians(1.0), 16, 0);
       _variation = src.getPhysicalQuantity(true, 0.0001, sail::Angle<double>::radians(1.0), 16, 0);
-      _reference = N2kField::castIntegerToOptional<Reference>(src.getUnsignedInSet(2, {0, 1}));
+      _reference = src.getUnsignedInSet(2, {0, 1}).cast<Reference>();
       _valid = _reference.defined();
     } else {
       reset();
@@ -66,7 +66,7 @@ namespace PgnClasses {
       _sid = src.getUnsigned(8, N2kField::Definedness::AlwaysDefined);
       _speedWaterReferenced = src.getPhysicalQuantity(false, 0.01, sail::Velocity<double>::metersPerSecond(1.0), 16, 0);
       _speedGroundReferenced = src.getPhysicalQuantity(false, 0.01, sail::Velocity<double>::metersPerSecond(1.0), 16, 0);
-      _speedWaterReferencedType = N2kField::castIntegerToOptional<SpeedWaterReferencedType>(src.getUnsignedInSet(4, {0, 1, 2, 3, 4}));
+      _speedWaterReferencedType = src.getUnsignedInSet(4, {0, 1, 2, 3, 4}).cast<SpeedWaterReferencedType>();
       _valid = _speedWaterReferencedType.defined();
     } else {
       reset();
@@ -87,7 +87,7 @@ namespace PgnClasses {
       _sid = src.getUnsigned(8, N2kField::Definedness::AlwaysDefined);
       _windSpeed = src.getPhysicalQuantity(false, 0.01, sail::Velocity<double>::metersPerSecond(1.0), 16, 0);
       _windAngle = src.getPhysicalQuantity(false, 0.0001, sail::Angle<double>::radians(1.0), 16, 0);
-      _reference = N2kField::castIntegerToOptional<Reference>(src.getUnsignedInSet(3, {0, 1, 2, 3, 4}));
+      _reference = src.getUnsignedInSet(3, {0, 1, 2, 3, 4}).cast<Reference>();
       _valid = _reference.defined();
     } else {
       reset();

--- a/src/device/anemobox/n2k/PgnClasses.h
+++ b/src/device/anemobox/n2k/PgnClasses.h
@@ -1,4 +1,4 @@
-/** Generated on Fri Jan 22 2016 14:54:17 GMT+0100 (CET) using 
+/** Generated on Fri Jan 22 2016 15:06:52 GMT+0100 (CET) using 
  *
  *     node /home/jonas/programmering/sailsmart/src/device/anemobox/n2k/codegen/index.js /home/jonas/programmering/cpp/canboat/analyzer/pgns.xml
  *

--- a/src/device/anemobox/n2k/codegen/gen.js
+++ b/src/device/anemobox/n2k/codegen/gen.js
@@ -481,7 +481,9 @@ function makeFieldAssignment(field, depth) {
         + signedExpr + ", " + getResolution(field) 
         + ", " + info.unit + ", " + bits + ", " + offset + ");"
     } else if (isLookupTable(field)) {
-      return lhs + "N2kField::castIntegerToOptional<" + getFieldType(field) + ">(src.getUnsignedInSet(" + bits + ", " + getEnumValueSet(field) + "));";
+      return lhs + "src.getUnsignedInSet(" 
+        + bits + ", " + getEnumValueSet(field) + ").cast<" 
+        + getFieldType(field) + ">();";
     } else { // Something else.
       return lhs
         + (signed? "src.getSigned(" : "src.getUnsigned(")

--- a/src/server/common/Optional.h
+++ b/src/server/common/Optional.h
@@ -80,6 +80,14 @@ class Optional {
     return other;
   }
 
+  template <typename Other>
+  Optional<Other> cast() const {
+    if (_defined) {
+      return Optional<Other>(Other(get()));
+    }
+    return Optional<Other>();
+  }
+
   bool isNan() const {
     if (_defined) {
       return genericIsNan(_value);


### PR DESCRIPTION
NMEA2000 fields with enumed values are now handled correctly.
