### PR TITLE
Add install script for anemonode cross-compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ www2/node_modules
 www2/uploads
 
 nodemodules/*/node_modules
+
+src/device/anemobox/anemonode/bin
+src/device/anemobox/canutils/can-utils
+src/device/anemobox/canutils/iproute2

--- a/src/device/anemobox/anemonode/install.sh
+++ b/src/device/anemobox/anemonode/install.sh
@@ -1,30 +1,31 @@
 #!/bin/bash
 set -e
 
+HOST=192.168.1.109
+
 rm -fR node_modules/mail node_modules/endpoint || true
 export NODE_ENV=production
 npm install
-npm prune --production
 
 node-gyp configure
 node-gyp build
 
-if [ -f ~/.ssh/id_rsa ]; then
-  echo "SSH Key already installed"
-else
-  echo "installing SSH Key"
-  mkdir -p ~/.ssh
-  cp id_rsa* ~/.ssh
-  chmod 600 ~/.ssh/id_rsa
-  cat known_hosts >> ~/.ssh/known_hosts
-fi
+npm prune --production
 
-[ -e /anemonode ] || git clone git+ssh://anemobox@vtiger.anemomind.com/home/anemobox/anemobox.git /anemonode
+../canutils/compile-can-utils.sh
+../canutils/compile-iproute2.sh
 
-rm -fR /anemonode/*
-rsync -ar --exclude="src/*" --exclude=id_rsa --exclude=install.sh . /anemonode
+EXCLUDE='--exclude="src" --exclude="*\.o" --exclude="binding.gyp" --exclude=README.md --exclude=install.sh --exclude=build/Release/obj'
 
-git rev-parse HEAD > /anemonode/commit
+git rev-parse HEAD > commit
+
+ssh root@${HOST} rm -fR "/anemonode/*"
+rsync -ar ${EXCLUDE} . root@${HOST}:/anemonode
+
+#[ -e /anemonode ] || git clone git+ssh://anemobox@vtiger.anemomind.com/home/anemobox/anemobox.git /anemonode
+#rm -fR /anemonode/*
+#rsync -ar --exclude="src/*" --exclude="*.o" --exclude=id_rsa --exclude=install.sh . /anemonode
+
 
 echo "Installed. After testing, please validate the release files with: "
 echo "  cd /anemonode ; git add . ; git commit ; git push"

--- a/src/device/anemobox/anemonode/run.sh
+++ b/src/device/anemobox/anemonode/run.sh
@@ -2,8 +2,15 @@
 mkdir -p /home/anemobox
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 
-RTC=/bin/rtc
-[ -e "${RTC}" ] && "${RTC}" --load
+if [ -f ~/.ssh/id_rsa ]; then
+  true
+else
+  echo "installing SSH Key"
+  mkdir -p ~/.ssh
+  cp id_rsa* ~/.ssh
+  chmod 600 ~/.ssh/id_rsa
+  cat known_hosts >> ~/.ssh/known_hosts
+fi
 
 ./format.sh
 

--- a/src/device/anemobox/anemonode/start_n2k.sh
+++ b/src/device/anemobox/anemonode/start_n2k.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+BIN="${HERE}/bin"
 # See https://github.com/kurt-vd/test-can-j1939
 # and
 # http://elinux.org/J1939
@@ -17,18 +19,20 @@ ADDR="0xc0288c00${UNIQUE_ID}"
 
 modprobe can-j1939
 
+IP=${BIN}/ip
+
 # do we need to configure can0?
 if ! (ifconfig | grep -q can0) ; then
-  ip link set can0 type can bitrate 250000
-  while ! ip link set can0 up; do sleep 1; done
-  ip link set can0 j1939 on
-  ip addr add j1939 name $ADDR dev can0
+  $IP link set can0 type can bitrate 250000
+  while ! $IP link set can0 up; do sleep 1; done
+  $IP link set can0 j1939 on
+  $IP addr add j1939 name $ADDR dev can0
   echo "Interface can0 configured with addr: $ADDR"
 fi
 
 # do we need to run jacd?
 if ! (ps aux | grep -v grep | grep jacd -q) ; then
   echo "starting address claim daemon with addr: $ADDR"
-  jacd $ADDR &
+  ${BIN}/jacd $ADDR &
 fi
 

--- a/src/device/anemobox/canutils/compile-can-utils.sh
+++ b/src/device/anemobox/canutils/compile-can-utils.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+CAN_DIR="${DIR}/can-utils"
+BIN=bin
+TARGETS="cansend candump jspy jacd jsr"
+[ -d "${CAN_DIR}" ] || git clone "git@github.com:jpilet/can-utils.git" "${CAN_DIR}"
+
+git -C "${CAN_DIR}" checkout j1939-v6
+git -C "${CAN_DIR}" pull
+make -C "${CAN_DIR}" -j2 ${TARGETS}
+
+[ -d "${BIN}" ] || mkdir "${BIN}"
+
+for i in $TARGETS; do
+  cp "${CAN_DIR}/$i" "${BIN}"
+done

--- a/src/device/anemobox/canutils/compile-iproute2.sh
+++ b/src/device/anemobox/canutils/compile-iproute2.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+IPROUTE2_DIR="${DIR}/iproute2"
+BIN=bin
+TARGETS="ip"
+[ -d "${IPROUTE2_DIR}" ] || git clone "git@github.com:jpilet/iproute2.git" "${IPROUTE2_DIR}"
+
+git -C "${IPROUTE2_DIR}" checkout j1939-v3.6
+git -C "${IPROUTE2_DIR}" pull
+make -C "${IPROUTE2_DIR}" -j2 SUBDIRS="lib ip"
+
+[ -d "${BIN}" ] || mkdir "${BIN}"
+
+for i in $TARGETS; do
+  cp "${IPROUTE2_DIR}/ip/$i" "${BIN}"
+done


### PR DESCRIPTION
add the compilation of j1939-specific tools.
a VM with a linux 32bits works fine to run install.sh.
