### PR TITLE
Remove useless "const" qualifier in return type

### DIFF
--- a/src/device/anemobox/logger/Logger.h
+++ b/src/device/anemobox/logger/Logger.h
@@ -192,42 +192,42 @@ struct ValueSetToTypedVector {
 
 template <>
 struct ValueSetToTypedVector<Angle<double> > {
-  static const void extract(const ValueSet &x, std::vector<Angle<double> > *dst) {
+  static void extract(const ValueSet &x, std::vector<Angle<double> > *dst) {
     Logger::unpack(x.angles(), dst);
   }
 };
 
 template <>
 struct ValueSetToTypedVector<Velocity<double> > {
-  static const void extract(const ValueSet &x, std::vector<Velocity<double> > *dst) {
+  static void extract(const ValueSet &x, std::vector<Velocity<double> > *dst) {
     Logger::unpack(x.velocity(), dst);
   }
 };
 
 template <>
 struct ValueSetToTypedVector<Length<double> > {
-  static const void extract(const ValueSet &x, std::vector<Length<double> > *dst) {
+  static void extract(const ValueSet &x, std::vector<Length<double> > *dst) {
     Logger::unpack(x.length(), dst);
   }
 };
 
 template <>
 struct ValueSetToTypedVector<GeographicPosition<double> > {
-  static const void extract(const ValueSet &x, std::vector<GeographicPosition<double> > *dst) {
+  static void extract(const ValueSet &x, std::vector<GeographicPosition<double> > *dst) {
     Logger::unpack(x.pos(), dst);
   }
 };
 
 template <>
 struct ValueSetToTypedVector<AbsoluteOrientation> {
-  static const void extract(const ValueSet &x, std::vector<AbsoluteOrientation> *dst) {
+  static void extract(const ValueSet &x, std::vector<AbsoluteOrientation> *dst) {
     Logger::unpack(x.orient(), dst);
   }
 };
 
 template <>
 struct ValueSetToTypedVector<TimeStamp> {
-  static const void extract(const ValueSet &x, std::vector<TimeStamp> *dst) {
+  static void extract(const ValueSet &x, std::vector<TimeStamp> *dst) {
     Logger::unpackTime(x, dst);
   }
 };


### PR DESCRIPTION
It makes sense to return a const&, but not a const value.
