### PR TITLE
Fix clang warnings

### DIFF
--- a/src/device/Arduino/libraries/CalibratedNav/CalibratedNav.h
+++ b/src/device/Arduino/libraries/CalibratedNav/CalibratedNav.h
@@ -51,9 +51,9 @@ class CalibratedNav {
   // InstrumentAbstraction can for instance be a Nav.
   template <typename InstrumentAbstraction>
   CalibratedNav(const InstrumentAbstraction &x) :
+    gpsMotion(HorizontalMotion<T>::polar(x.gpsSpeed(), x.gpsBearing())),
     rawAwa(x.awa()), rawMagHdg(x.magHdg()),
     rawAws(x.aws()), rawWatSpeed(x.watSpeed()),
-    gpsMotion(HorizontalMotion<T>::polar(x.gpsSpeed(), x.gpsBearing())),
     driftAngle(Angle<T>::degrees(T(0))) {}
 
   bool hasNan() const {

--- a/src/device/Arduino/libraries/Corrector/Corrector.h
+++ b/src/device/Arduino/libraries/Corrector/Corrector.h
@@ -41,7 +41,7 @@ namespace sail {
   template <typename T>
   class SpeedCorrector {
    public:
-    SpeedCorrector(T k_, T m_, T c_, T alpha_) : k(k_), c(c_), m(m_), alpha(alpha_) {}
+    SpeedCorrector(T k_, T m_, T c_, T alpha_) : k(k_), m(m_), c(c_), alpha(alpha_) {}
     T k, m, c, alpha;
 
     SpeedCorrector() :

--- a/src/server/common/Functional.h
+++ b/src/server/common/Functional.h
@@ -107,7 +107,7 @@ class Mapped {
  public:
   typedef Mapped<ResultType> ThisType;
 
-  Mapped(std::function<ResultType(int)> f, int size) : _f(f), _size(size) {}
+  Mapped(std::function<ResultType(int)> f, int size) : _size(size), _f(f) {}
 
   int size() const {
     return _size;
@@ -166,7 +166,6 @@ auto map(CollectionA X, CollectionB Y, Function f) -> decltype(vmap(f, X, Y)) {
 template <typename Function, typename Collection>
 auto filter(Collection X, Function f) -> Array<decltype(X[0])> {
   int n = X.size();
-  int counter = 0;
   ArrayBuilder<decltype(X[0])> Y(n);
   for (int i = 0; i < n; i++) {
     if (f(X[i])) {

--- a/src/server/common/Hierarchy.cpp
+++ b/src/server/common/Hierarchy.cpp
@@ -22,7 +22,8 @@ bool HNode::operator== (const HNode &other) const {
       && _description == other._description && _code == other._code;
 }
 
-HNode::HNode(int index, int parent, std::string code, std::string label) : _index(index), _parent(parent), _code(code), _description(label) {
+HNode::HNode(int index, int parent, std::string code, std::string label)
+    : _index(index), _parent(parent), _description(label), _code(code) {
 }
 
 namespace {

--- a/src/server/common/HistogramTest.cpp
+++ b/src/server/common/HistogramTest.cpp
@@ -24,7 +24,6 @@ TEST(HistgramTest, BasicMapping) {
 }
 
 TEST(HistgramTest, Counting) {
-  const double marg = 1.0e-6;
   HistogramMap<double, false> h(2, 1.0, 3.0);
   const int xn = 3;
   double xdata[xn] = {1.2, 1.3, 2.9};

--- a/src/server/common/Span.h
+++ b/src/server/common/Span.h
@@ -46,7 +46,6 @@ class Span {
   Span(T value) : _minv(value), _maxv(value), _initialized(true) {}
   Span(Array<T> arr) {
     _initialized = false;
-    int count = arr.size();
     for (auto e: arr) {
       extend(e);
     }

--- a/src/server/math/BandMat.h
+++ b/src/server/math/BandMat.h
@@ -261,8 +261,6 @@ namespace BMGE {
 template <typename T>
 bool bandMatGaussElimDestructive(BandMat<T> *Aio, MDArray<T, 2> *Bio, double tol = 1.0e-6) {
   using namespace BMGE;
-  BandMat<T> &A = *Aio;
-  MDArray<T, 2> &B = *Bio;
   if (!eliminateForward(Aio, Bio, tol)) {
     *Aio = BandMat<T>();
     *Bio = MDArray<T, 2>();

--- a/src/server/math/LUImpl.h
+++ b/src/server/math/LUImpl.h
@@ -187,7 +187,6 @@ void backsubst(MDArray<T, 2> R, MDArray<T, 2> C, MDArray<T, 2> &X) {
 // Eldén, Numeriska Beräkningar, page 211
 template <typename T>
 void solveLinearSystemLU(MDArray<T, 2> A, MDArray<T, 2> b, MDArray<T, 2> *xOut) {
-  T *xinit = xOut->ptr();
   MDArray<T, 2> LR, y;
   Array<int> P;
   decomposeLU<T>(A, &LR, &P);

--- a/src/server/math/PiecewisePolynomials.h
+++ b/src/server/math/PiecewisePolynomials.h
@@ -124,7 +124,7 @@ namespace INTERNAL {
           Joint() : _left(-1), _middle(-1), _right(-1), _increase(NAN) {}
 
           Joint(int left, int middle, int right, Integral1d<QuadForm<N, 1> > itg) :
-            _left(left), _middle(middle), _right(right), _itg(itg) {
+            _itg(itg), _left(left), _middle(middle), _right(right) {
             computeIncrease();
           }
 

--- a/src/server/math/SignalCovariance.h
+++ b/src/server/math/SignalCovariance.h
@@ -113,8 +113,6 @@ T slidingWindowVariance(Arrayd time, Integral1d<T> X, Integral1d<T> X2, int wind
   WeightedValue<T> sum{T(0), T(0)};
   int windowCount = time.size() - windowSize;
 
-  auto maxWeight = T(0);
-  auto maxWeightedValue = T(0);
   for (int i = 0; i < windowCount; i++) {
     int from = i;
     int to = from + windowSize;
@@ -128,8 +126,8 @@ T slidingWindowVariance(Arrayd time, Integral1d<T> X, Integral1d<T> X2, int wind
 template <typename T>
 struct SignalData {
  SignalData(Arrayd times, Array<T> signal, Settings s) :
-   time(times), X(signal), itgX(signal), _variance(-1),
-   _windowSize(s.windowSize) {
+   time(times), X(signal), itgX(signal),
+   _windowSize(s.windowSize), _variance(-1) {
    assert(!isNaN(X));
  }
 

--- a/src/server/math/irls.h
+++ b/src/server/math/irls.h
@@ -171,8 +171,8 @@ class BinaryConstraintGroup : public WeightingStrategy {
 
 class NonNegativeConstraint : public WeightingStrategy {
  public:
-  NonNegativeConstraint() : _index(-1), _lastWeight(0) {}
-  NonNegativeConstraint(int index) : _index(index), _lastWeight(0) {}
+  NonNegativeConstraint() : _lastWeight(0), _index(-1) {}
+  NonNegativeConstraint(int index) :  _lastWeight(0), _index(index) {}
   void apply(
     double constraintWeight,
     const Arrayd &residuals, QuadCompiler *dst) {

--- a/src/server/math/nonlinear/DataFit.h
+++ b/src/server/math/nonlinear/DataFit.h
@@ -126,7 +126,6 @@ void makeDataFromObservations(Array<Observation<Dim> > observations,
   assert(observations.size() == dataRows.count());
   assert(dataRows.dim() == Dim);
   assert(sampleCols.dim() == Dim);
-  int count = observations.size();
   for (auto i: dataRows.coordinateSpan()) {
     const Observation<Dim> &obs = observations[i];
     auto rowSpan = dataRows.span(i);

--- a/src/server/math/nonlinear/SignalUtils.h
+++ b/src/server/math/nonlinear/SignalUtils.h
@@ -203,7 +203,6 @@ class AbsCost {
     return (x < 0? -1 : 1);
   }
  private:
-  double _tao;
 };
 
 class SquareCost {

--- a/src/server/nautical/FlowErrors.h
+++ b/src/server/nautical/FlowErrors.h
@@ -79,8 +79,7 @@ class FlowErrors {
   FlowErrors(const Error<Velocity<double> > &ne,
       const Error<Velocity<double> > &me,
       const Error<Angle<double> > &ae) :
-      _normError(ne), _angleError(ae),
-      _magnitudeError(me) {}
+      _normError(ne), _magnitudeError(me), _angleError(ae) { }
   Error<Velocity<double> > _normError, _magnitudeError;
   Error<Angle<double> > _angleError;
   static double nanIfEmpty(const MeanAndVar &mv, double x) {

--- a/src/server/nautical/MinCovCalib.cpp
+++ b/src/server/nautical/MinCovCalib.cpp
@@ -146,7 +146,7 @@ Arrayd getTimes(FilteredNavData data) {
 
 class ObjfOrientation {
  public:
-  ObjfOrientation(FilteredNavData data, Settings s) : _data(data), _settings(s),
+  ObjfOrientation(FilteredNavData data, Settings s) : _settings(s), _data(data),
     _residualCountPerPair(s.covarianceSettings.calcResidualCount(data.size())),
     _times(getTimes(data)) {}
 

--- a/src/server/nautical/synthtest/BoatSim.cpp
+++ b/src/server/nautical/synthtest/BoatSim.cpp
@@ -162,7 +162,6 @@ Array<BoatSim::FullState> BoatSim::simulate(Duration<double> simulationDuration,
 BoatSim::TwaFunction BoatSim::makePiecewiseTwaFunction(
     Array<Duration<double> > durs,
     Array<Angle<double> > twa) {
-  int count = durs.size();
   Arrayd dursSeconds = toArray(map(durs, [](Duration<double> x) {return x.seconds();}));
   ProportionateIndexer indexer(dursSeconds);
   return [=](Duration<double> x) {

--- a/src/server/nautical/synthtest/BoatSim.h
+++ b/src/server/nautical/synthtest/BoatSim.h
@@ -154,8 +154,8 @@ class BoatCharacteristics {
     halfTargetSpeedTime(Duration<double>::seconds(3.0)),
     rudderCorrectionCoef(2.0),
     rudderMaxAngle(Angle<double>::degrees(15)),
-    correctionThreshold(Angle<double>::degrees(5)),
     rudderFineTune(Angle<double>::degrees(1)),
+    correctionThreshold(Angle<double>::degrees(5)),
     boatReactiveness(20.0)
     {}
 


### PR DESCRIPTION
Mostly "xxx member will be initialized before yyy member"
and "unused variable".
