### PR TITLE
Include Eigen as system headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if (${FULL_BUILD})
   include("cmake/FindF2C.cmake")
 
   find_package(Eigen3 REQUIRED)
-  include_directories(${EIGEN3_INCLUDE_DIR})
+  include_directories(SYSTEM ${EIGEN3_INCLUDE_DIR})
 
   find_package(LAPACK REQUIRED)
   find_package(BLAS REQUIRED)


### PR DESCRIPTION
To suppress warnings on GCC 5 that we cannot do much about.
