### PR TITLE
Avoid operator overloading to make it compile

### DIFF
--- a/src/server/common/TimedValuePairsTest.cpp
+++ b/src/server/common/TimedValuePairsTest.cpp
@@ -30,14 +30,26 @@ namespace {
 
   typedef std::pair<TimedValue<int>, TimedValue<std::string> > Pair;
 
-
   template <typename T>
-  bool operator==(const TimedValue<T> &a, const TimedValue<T> &b) {
+  bool equal(const TimedValue<T> &a, const TimedValue<T> &b) {
     return a.time == b.time && a.value == b.value;
   }
 
-  bool operator==(const Pair &a, const Pair &b) {
-    return a.first == b.first && a.second == b.second;
+  bool equal(const Pair &a, const Pair &b) {
+    return equal(a.first, b.first) && equal(a.second, b.second);
+  }
+
+  bool equalArrays(const Array<Pair> &a, const Array<Pair> &b) {
+    if (a.size() != b.size()) {
+      return false;
+    }
+    int n = a.size();
+    for (int i = 0; i < n; i++) {
+      if (!equal(a[i], b[i])) {
+        return false;
+      }
+    }
+    return true;
   }
 }
 
@@ -68,7 +80,7 @@ TEST(TVPTest, OnePair) {
   Array<TimedValue<std::string> > B{tv(0.0, "rulle")};
   auto C = TimedValuePairs::makeTimedValuePairs(A.begin(), A.end(), B.begin(), B.end());
   EXPECT_EQ(C.size(), 1);
-  EXPECT_TRUE(Pair(C[0]) == (Pair{tv(0.0, 119), tv(0.0, "rulle")}));
+  EXPECT_TRUE(equal(Pair(C[0]), (Pair{tv(0.0, 119), tv(0.0, "rulle")})));
 }
 
 TEST(TVPTest, TwoPairs) {
@@ -76,10 +88,10 @@ TEST(TVPTest, TwoPairs) {
   Array<TimedValue<std::string> > B{tv(0.1, "rulle")};
   auto C = TimedValuePairs::makeTimedValuePairs(A.begin(), A.end(), B.begin(), B.end());
   EXPECT_EQ(C.size(), 2);
-  EXPECT_TRUE(C == (Array<Pair>{
+  EXPECT_TRUE(equalArrays(C, (Array<Pair>{
     Pair{tv(0.0, 119), tv(0.1, "rulle")},
     Pair{tv(1.0, 120), tv(0.1, "rulle")}
-  }));
+  })));
 }
 
 TEST(TVPTest, TwoSeparatePairs) {
@@ -87,10 +99,10 @@ TEST(TVPTest, TwoSeparatePairs) {
   Array<TimedValue<std::string> > B{tv(0.1, "rulle"), tv(0.2, "bulle")};
   auto C = TimedValuePairs::makeTimedValuePairs(A.begin(), A.end(), B.begin(), B.end());
   EXPECT_EQ(C.size(), 2);
-  EXPECT_TRUE(C == (Array<Pair>{
+  EXPECT_TRUE(equalArrays(C, (Array<Pair>{
     Pair{tv(0.0, 119), tv(0.1, "rulle")},
     Pair{tv(1.0, 120), tv(0.2, "bulle")}
-  }));
+  })));
 }
 
 TEST(TVPTest, TwoSeparatePairsAndOneUnusedSample) {
@@ -98,8 +110,8 @@ TEST(TVPTest, TwoSeparatePairsAndOneUnusedSample) {
   Array<TimedValue<std::string> > B{tv(0.1, "rulle"), tv(0.15, "unused"), tv(0.2, "bulle")};
   auto C = TimedValuePairs::makeTimedValuePairs(A.begin(), A.end(), B.begin(), B.end());
   EXPECT_EQ(C.size(), 2);
-  EXPECT_TRUE(C == (Array<Pair>{
+  EXPECT_TRUE(equalArrays(C, (Array<Pair>{
     Pair{tv(0.0, 119), tv(0.1, "rulle")},
     Pair{tv(1.0, 120), tv(0.2, "bulle")}
-  }));
+  })));
 }


### PR DESCRIPTION
I cannot reproduce the compilation error that @jpilet gets:

```
[  6%] Building CXX object src/server/common/CMakeFiles/common_TimedValuePairsTest.dir/TimedValuePairsTest.cpp.o
In file included from /Users/leto/Documents/anemomind/anemomind/src/server/common/TimedValuePairsTest.cpp:8:
In file included from /Users/leto/Documents/anemomind/anemomind/build/third-party/gmock-src/gtest/include/gtest/gtest.h:55:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/ostream:138:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/ios:216:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__locale:15:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/string:439:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/algorithm:627:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/utility:410:22: error: invalid operands to binary expression ('const sail::TimedValue<int>' and 'const sail::TimedValue<int>')
    return __x.first == __y.first && __x.second == __y.second;
           ~~~~~~~~~ ^  ~~~~~~~~~
/Users/leto/Documents/anemomind/anemomind/src/server/common/Array.h:453:22: note: in instantiation of function template specialization 'std::__1::operator==<sail::TimedValue<int>, sail::TimedValue<std::__1::basic_string<char> > >' requested here
      if (!(_data[i] == other._data[i])) {
                     ^
/Users/leto/Documents/anemomind/anemomind/src/server/common/TimedValuePairsTest.cpp:79:17: note: in instantiation of member function 'sail::Array<std::__1::pair<sail::TimedValue<int>, sail::TimedValue<std::__1::basic_string<char> > > >::operator==' requested here
  EXPECT_TRUE(C == (Array<Pair>{
                ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/utility:408:1: note: candidate template ignored: could not match 'pair' against 'TimedValue'
operator==(const pair<_T1,_T2>& __x, const pair<_T1,_T2>& __y)
^
1 error generated.
make[2]: *** [src/server/common/CMakeFiles/common_TimedValuePairsTest.dir/TimedValuePairsTest.cpp.o] Error 1
make[1]: *** [src/server/common/CMakeFiles/common_TimedValuePairsTest.dir/all] Error 2
make: *** [all] Error 2
```

But I hope this PR will fix it
