### PR TITLE
Fix processNewLogs.sh when called from crontab

### DIFF
--- a/src/server/production/processNewLogs.sh
+++ b/src/server/production/processNewLogs.sh
@@ -79,6 +79,7 @@ SSH_TUNNEL_PID=$!
 # wait for the tunnel to open.
 sleep 1
 
+export SHELL=/bin/bash
 parallel -j 3 processBoat ::: "${LOG_DIR}/"*
 
 kill $SSH_TUNNEL_PID


### PR DESCRIPTION
crontab uses /bin/sh, not /bin/bash as shell. As a result, it broke the trick
of exporting a function to be called by "parallel".
Explicitely telling parallel which shell to use fixes the problem.
