### PR TITLE
Make positiveMod work with non-finite values

### DIFF
--- a/src/server/common/PositiveMod.h
+++ b/src/server/common/PositiveMod.h
@@ -44,14 +44,19 @@ T reduceCyclically(T a, T b) {
 template <typename T>
 T positiveMod(T a, T b) {
   T zero = b - b; // Because T(0) constructor does not exist for all types T.
-  if (a < zero) {
-    return positiveMod(makePositiveCyclic(a, b), b);
+  T a2 = a + a;
+  if (a < a2 || a2 < a) { // a is non-zero and finite
+    if (a < zero) {
+      return positiveMod(makePositiveCyclic(a, b), b);
+    }
+    T c = a;
+    while (!(c < b)) {
+      c = reduceCyclically(c, b);
+    }
+    return c;
+  } else { // a is zero or non-finite
+    return a;
   }
-  T c = a;
-  while (!(c < b)) {
-    c = reduceCyclically(c, b);
-  }
-  return c;
 }
 
 

--- a/src/server/common/PositiveModTest.cpp
+++ b/src/server/common/PositiveModTest.cpp
@@ -88,3 +88,12 @@ TEST(PositiveModTest, WithCeres) {
   EXPECT_EQ(3.0, positiveMod(AD(-1.0), AD(4.0)).a);
 }
 
+TEST(PositiveModTest, NaNValue) {
+  EXPECT_TRUE(std::isnan(positiveMod(std::numeric_limits<double>::quiet_NaN(), 2.0)));
+}
+
+TEST(PositiveModTest, InfValue) {
+  EXPECT_TRUE(std::isinf(positiveMod(std::numeric_limits<double>::infinity(), 2.0)));
+  EXPECT_TRUE(std::isinf(positiveMod(-std::numeric_limits<double>::infinity(), 2.0)));
+}
+


### PR DESCRIPTION
Without this fix, there will be an infinite loop if `a` is not finite. I also considered using isFinite defined in `server/common/numerics.h` for this, but that would have required a lot of changes in many other different parts of the code to accomodate for FixedPoint and ceres::Jet.
