### PR TITLE
Clean times when loading log files

### DIFF
--- a/src/device/Arduino/NMEAStats/test/ScreenRecordingSimulatorTest.cpp
+++ b/src/device/Arduino/NMEAStats/test/ScreenRecordingSimulatorTest.cpp
@@ -22,7 +22,8 @@ TEST(ScreenRecordingTest, screenAtTest) {
   NavDataset navs = LogLoader::loadNavDataset(nmeaFile);
 
   int n = getNavSize(navs);
-  EXPECT_EQ(11, n);
+  EXPECT_LE(10, n);
+  EXPECT_LE(n, 11);
   int failureCount = 0;
   for (int i = 0; i < n; ++i) {
     ScreenInfo info;

--- a/src/device/Arduino/libraries/NmeaParser/NmeaParser.cpp
+++ b/src/device/Arduino/libraries/NmeaParser/NmeaParser.cpp
@@ -207,10 +207,11 @@ NmeaParser::NmeaSentence NmeaParser::processByte(Byte input) {
     state_ = NP_STATE_CHECKSUM_2;
     break;
 
-  case NP_STATE_CHECKSUM_2 :
+  case NP_STATE_CHECKSUM_2 : {
     receivedChecksum_ |= HexDigitToInt(input);
 
-    if(ignoreWrongChecksum_ || checksum_ == receivedChecksum_) {
+    bool lastChecksumWasGood = checksum_ == receivedChecksum_;
+    if(ignoreWrongChecksum_ || lastChecksumWasGood) {
       ret = processCommand();
     } else {
       numErr_++;
@@ -218,7 +219,7 @@ NmeaParser::NmeaSentence NmeaParser::processByte(Byte input) {
     state_ = NP_STATE_SOM;
 
     break;
-
+  }
   default:
     state_ = NP_STATE_SOM;
   }

--- a/src/device/anemobox/Nmea0183Adaptor.h
+++ b/src/device/anemobox/Nmea0183Adaptor.h
@@ -23,49 +23,48 @@ inline GeographicPosition<double> getPos(const NmeaParser& parser) {
 }
 
 template <typename Handler>
-void Nmea0183ProcessByte(const std::string &sourceName,
-    unsigned char b, NmeaParser *parser, Handler *handler) {
+void Nmea0183ProcessByte(unsigned char b, NmeaParser *parser, Handler *handler) {
   switch (parser->processByte(b)) {
     case NmeaParser::NMEA_NONE:
     case NmeaParser::NMEA_UNKNOWN: break;
     case NmeaParser::NMEA_RMC:
-      handler->template add<DATE_TIME>(sourceName, getTime(*parser));
-      handler->template add<GPS_BEARING>(sourceName,
+      handler->template add<DATE_TIME>(*parser, getTime(*parser));
+      handler->template add<GPS_BEARING>(*parser,
                                 static_cast<Angle<double>>(parser->gpsBearing()));
-      handler->template add<GPS_SPEED>(sourceName,
+      handler->template add<GPS_SPEED>(*parser,
                                 static_cast<Velocity<double>>(parser->gpsSpeed()));
-      handler->template add<GPS_POS>(sourceName, getPos(*parser));
+      handler->template add<GPS_POS>(*parser, getPos(*parser));
       break;
     case NmeaParser::NMEA_AW:
-      handler->template add<AWA>(sourceName, static_cast<Angle<double>>(parser->awa()));
-      handler->template add<AWS>(sourceName, static_cast<Velocity<double>>(parser->aws()));
+      handler->template add<AWA>(*parser, static_cast<Angle<double>>(parser->awa()));
+      handler->template add<AWS>(*parser, static_cast<Velocity<double>>(parser->aws()));
       break;
     case NmeaParser::NMEA_TW:
-      handler->template add<TWA>(
-          sourceName, static_cast<Angle<double>>(parser->twa()));
-      handler->template add<TWS>(
-          sourceName, static_cast<Velocity<double>>(parser->tws()));
+      handler->template add<TWA>(*parser,
+          static_cast<Angle<double>>(parser->twa()));
+      handler->template add<TWS>(*parser,
+          static_cast<Velocity<double>>(parser->tws()));
       break;
     case NmeaParser::NMEA_WAT_SP_HDG:
-      handler->template add<MAG_HEADING>(
-          sourceName, static_cast<Angle<double>>(parser->magHdg()));
-      handler->template add<WAT_SPEED>(
-          sourceName, static_cast<Velocity<double>>(parser->watSpeed()));
+      handler->template add<MAG_HEADING>(*parser,
+          static_cast<Angle<double>>(parser->magHdg()));
+      handler->template add<WAT_SPEED>(*parser,
+          static_cast<Velocity<double>>(parser->watSpeed()));
       break;
     case NmeaParser::NMEA_VLW: break;
-      handler->template add<WAT_DIST>(
-          sourceName, static_cast<Length<double>>(parser->watDist()));
+      handler->template add<WAT_DIST>(*parser,
+          static_cast<Length<double>>(parser->watDist()));
     case NmeaParser::NMEA_GLL:
-      handler->template add<GPS_POS>(sourceName, getPos(*parser));
+      handler->template add<GPS_POS>(*parser, getPos(*parser));
       break;
     case NmeaParser::NMEA_VTG:
-      handler->template add<GPS_BEARING>(
-          sourceName, static_cast<Angle<double>>(parser->gpsBearing()));
-      handler->template add<GPS_SPEED>(
-          sourceName, static_cast<Velocity<double>>(parser->gpsSpeed()));
+      handler->template add<GPS_BEARING>(*parser,
+          static_cast<Angle<double>>(parser->gpsBearing()));
+      handler->template add<GPS_SPEED>(*parser,
+          static_cast<Velocity<double>>(parser->gpsSpeed()));
       break;
     case NmeaParser::NMEA_ZDA:
-      handler->template add<DATE_TIME>(sourceName, getTime(*parser));
+      handler->template add<DATE_TIME>(*parser, getTime(*parser));
       break;
   }
 }

--- a/src/device/anemobox/Nmea0183Source.cpp
+++ b/src/device/anemobox/Nmea0183Source.cpp
@@ -12,24 +12,27 @@ namespace {
 
   class DispatcherAdaptor {
    public:
-    DispatcherAdaptor(Dispatcher *d) : _dispatcher(d) {}
+    DispatcherAdaptor(const std::string &sourceName,
+        Dispatcher *d) : _sourceName(sourceName), _dispatcher(d) {}
 
     template <DataCode Code>
-    void add(const std::string &sourceName, const typename TypeForCode<Code>::type &value) {
-      _dispatcher->publishValue(Code, sourceName, value);
+    void add(const NmeaParser &parser,
+        const typename TypeForCode<Code>::type &value) {
+      _dispatcher->publishValue(Code, _sourceName, value);
     }
 
    private:
+    std::string _sourceName;
     Dispatcher *_dispatcher;
   };
 
 }
 
 void Nmea0183Source::process(const unsigned char* buffer, int length) {
-  DispatcherAdaptor adaptor(_dispatcher);
+  DispatcherAdaptor adaptor(_sourceName, _dispatcher);
   for (ssize_t i = 0; i < length; ++i) {
-    Nmea0183ProcessByte<DispatcherAdaptor>(_sourceName, buffer[i],
-        &_parser, &adaptor);
+    Nmea0183ProcessByte<DispatcherAdaptor>(
+        buffer[i], &_parser, &adaptor);
   }
 } 
 

--- a/src/device/anemobox/logger/Logger.cpp
+++ b/src/device/anemobox/logger/Logger.cpp
@@ -212,7 +212,9 @@ namespace {
     std::int64_t time = 0;
     for (int i = 0; i < times.size(); ++i) {
       time += times.Get(i);
-      result->push_back(TimeStamp::fromMilliSecondsSince1970(time));
+      auto t = TimeStamp::fromMilliSecondsSince1970(time);
+      CHECK(t < TimeStamp::UTC(2020, 1, 1, 1, 1, 1));
+      result->push_back(t);
     }
   }
 }

--- a/src/server/nautical/BoatLogProcessor.cpp
+++ b/src/server/nautical/BoatLogProcessor.cpp
@@ -258,7 +258,6 @@ bool BoatLogProcessor::process(ArgMap* amap) {
   readArgs(amap);
 
   NavDataset raw = loadNavs(*amap, _boatid);
-
   NavDataset resampled = downSampleGpsTo1Hz(raw);
 
   // Note: the grammar does not have access to proper true wind.
@@ -279,6 +278,14 @@ bool BoatLogProcessor::process(ArgMap* amap) {
 
   if (_saveSimulated.size() > 0) {
     saveDispatcher(_saveSimulated.c_str(), *(simulated.dispatcher()));
+  }
+
+  if (_debug) {
+    auto bounds = resampled.computeBounds();
+    if (bounds.initialized()) {
+      LOG(INFO) << "Measurements spanning " <<
+          bounds.minv() << " to " << bounds.maxv() << std::endl;
+    }
   }
 
   outputTargetSpeedTable(_debug, 

--- a/src/server/nautical/NavCompatibility.cpp
+++ b/src/server/nautical/NavCompatibility.cpp
@@ -146,7 +146,8 @@ namespace {
   template <DataCode Code>
   Optional<typename TypeForCode<Code>::type> getValue(
       const NavDataset &src, const TimeStamp &time) {
-    auto nearest = src.samples<Code>().nearest(time);
+    const auto &samples = src.samples<Code>();
+    auto nearest = samples.nearest(time);
     if (nearest.defined()) {
       if (fabs(nearest.get().time - time) < maxMergeDif) {
         return Optional<typename TypeForCode<Code>::type>(nearest.get().value);
@@ -158,7 +159,9 @@ namespace {
   template<DataCode code, class T>
   void setNavValue(const NavDataset &dataset, TimeStamp time, Nav *dst, void (Nav::* set)(T)) {
       auto x = getValue<code>(dataset, time);
-      if (x.defined()) { ((*dst).*set)(x()); }
+      if (x.defined()) {
+        ((*dst).*set)(x());
+      }
   }
 
   template <DataCode Code>

--- a/src/server/nautical/NavDataset.h
+++ b/src/server/nautical/NavDataset.h
@@ -20,6 +20,7 @@
 #include <server/common/TimeStamp.h>
 #include <device/anemobox/TimedSampleCollection.h>
 #include <server/nautical/types/SampledSignal.h>
+#include <server/common/Span.h>
 
 
 namespace sail {
@@ -173,6 +174,7 @@ public:
   TimeStamp upperBound() const;
   Duration<double> duration() const;
 
+  Span<TimeStamp> computeBounds() const;
   NavDataset fitBounds() const;
 
   // Return a range of samples given the code.

--- a/src/server/nautical/logimport/CMakeLists.txt
+++ b/src/server/nautical/logimport/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(logimport_ProtobufLogLoader
 target_link_libraries(logimport_ProtobufLogLoader
                       anemobox_Logger
                       anemobox_Dispatcher
+                      logimport_TimeReconstructor
                      )  
 
 add_library(logimport_Nmea0183Loader
@@ -150,3 +151,18 @@ target_link_libraries(logimport_summary
                       logimport_LogLoader
                       nautical_NavDataset
                      )
+
+add_library(logimport_TimeReconstructor
+            TimeReconstructor.h
+            TimeReconstructor.cpp
+            )
+
+target_link_libraries(logimport_TimeReconstructor
+                      common_logging
+                      common_TimeStamp
+                     )
+cxx_test(logimport_TimeReconstructorTest
+         TimeReconstructorTest.cpp
+         logimport_TimeReconstructor
+         gtest_main
+         )

--- a/src/server/nautical/logimport/LogLoader.cpp
+++ b/src/server/nautical/logimport/LogLoader.cpp
@@ -22,17 +22,18 @@
 namespace sail {
 
 
+LogLoader::LogLoader(const LogLoaderSettings &settings) : _settings(settings) {}
 
 bool LogLoader::loadFile(const std::string &filename) {
   std::string ext = toLower(Poco::Path(filename).getExtension());
   if (ext == "txt") {
-    Nmea0183Loader::loadNmea0183File(filename, &_acc);
+    Nmea0183Loader::loadNmea0183File(filename, &_acc, _settings);
     return true;
   } else if (ext == "csv") {
     loadCsv(filename, &_acc);
     return true;
   } else if (ext == "log") {
-    return ProtobufLogLoader::load(filename, &_acc);
+    return ProtobufLogLoader::load(filename, &_acc, _settings);
   } else {
     LOG(ERROR) << filename << ": unknown log file extension.";
     return false;
@@ -41,7 +42,8 @@ bool LogLoader::loadFile(const std::string &filename) {
 
 void LogLoader::loadNmea0183(std::istream *s) {
   Nmea0183Loader::loadNmea0183Stream(s, &_acc,
-      Nmea0183Loader::getDefaultSourceName());
+      Nmea0183Loader::getDefaultSourceName(),
+      _settings);
 }
 
 void LogLoader::load(const std::string &name) {
@@ -49,7 +51,7 @@ void LogLoader::load(const std::string &name) {
 }
 
 void LogLoader::load(const LogFile &data) {
-  ProtobufLogLoader::load(data, &_acc);
+  ProtobufLogLoader::load(data, &_acc, _settings);
 }
 
 void LogLoader::load(const Poco::Path &name) {
@@ -69,14 +71,16 @@ void LogLoader::load(const Poco::Path &name) {
   }, settings);
 }
 
-NavDataset LogLoader::loadNavDataset(const std::string &name) {
-  LogLoader loader;
+NavDataset LogLoader::loadNavDataset(const std::string &name,
+    const LogLoaderSettings &settings) {
+  LogLoader loader(settings);
   loader.load(name);
   return loader.makeNavDataset();
 }
 
-NavDataset LogLoader::loadNavDataset(const Poco::Path &name) {
-  LogLoader loader;
+NavDataset LogLoader::loadNavDataset(const Poco::Path &name,
+    const LogLoaderSettings &settings) {
+  LogLoader loader(settings);
   loader.load(name);
   return loader.makeNavDataset();
 }

--- a/src/server/nautical/logimport/LogLoader.h
+++ b/src/server/nautical/logimport/LogLoader.h
@@ -8,6 +8,7 @@
 
 #include <server/nautical/NavDataset.h>
 #include <server/nautical/logimport/LogAccumulator.h>
+#include <server/nautical/logimport/LogLoaderSettings.h>
 
 namespace Poco {class Path;}
 
@@ -28,6 +29,9 @@ class LogFile;
  */
 class LogLoader {
  public:
+  LogLoader(const LogLoaderSettings &settings
+      = LogLoaderSettings());
+
   // Load a file.
   bool loadFile(const std::string &filename);
 
@@ -37,8 +41,10 @@ class LogLoader {
 
   // Conveniency functions when there is just one thing
   // to load.
-  static NavDataset loadNavDataset(const std::string &name);
-  static NavDataset loadNavDataset(const Poco::Path &name);
+  static NavDataset loadNavDataset(const std::string &name, const LogLoaderSettings &settings
+      = LogLoaderSettings());
+  static NavDataset loadNavDataset(const Poco::Path &name, const LogLoaderSettings &settings
+      = LogLoaderSettings());
 
   void addToDispatcher(Dispatcher *dst) const;
   NavDataset makeNavDataset() const;
@@ -51,6 +57,7 @@ class LogLoader {
   void load(const LogFile &data);
 
  private:
+  LogLoaderSettings _settings;
   LogAccumulator _acc;
   void loadValueSet(const ValueSet &set);
   void loadTextData(const ValueSet &stream);

--- a/src/server/nautical/logimport/LogLoaderSettings.h
+++ b/src/server/nautical/logimport/LogLoaderSettings.h
@@ -1,0 +1,25 @@
+/*
+ * LogLoaderSettings.h
+ *
+ *  Created on: Jul 14, 2016
+ *      Author: jonas
+ */
+
+#ifndef SERVER_NAUTICAL_LOGIMPORT_LOGLOADERSETTINGS_H_
+#define SERVER_NAUTICAL_LOGIMPORT_LOGLOADERSETTINGS_H_
+
+namespace sail {
+  struct LogLoaderSettings {
+    bool ignoreNmea0183Checksum = false;
+
+    static LogLoaderSettings relaxed() {
+      LogLoaderSettings dst;
+      dst.ignoreNmea0183Checksum = true;
+      return dst;
+    }
+  };
+}
+
+
+
+#endif /* SERVER_NAUTICAL_LOGIMPORT_LOGLOADERSETTINGS_H_ */

--- a/src/server/nautical/logimport/Nmea0183Loader.cpp
+++ b/src/server/nautical/logimport/Nmea0183Loader.cpp
@@ -11,13 +11,80 @@
 #include <device/anemobox/Nmea0183Adaptor.h>
 #include <server/nautical/logimport/SourceGroup.h>
 #include <fstream>
+#include <server/common/IntervalUtils.h>
 
 namespace sail {
 namespace Nmea0183Loader {
 
-LogLoaderNmea0183Parser::LogLoaderNmea0183Parser(LogAccumulator *dst,
-  const std::string &s) : _dst(dst), _sourceName(s) {
-  setIgnoreWrongChecksum(true);
+namespace {
+  Arrayi makeIndexToIntervalMap(int n, Array<IndexedTime> times) {
+    Arrayi dst = Arrayi::fill(n, -1);
+    int from = 0;
+    int to = 0;
+    for (int i = 0; i < times.size() - 1; i++) {
+      from = times[i].index;
+      to = times[i+1].index;
+      for (int j = from; j < to; j++) {
+        dst[j] = i;
+      }
+    }
+    for (int i = to; i < n; i++) {
+      dst[i] = times.size();
+    }
+    return dst;
+  }
+}
+
+std::function<TimeStamp(int)> makeNmeaIndexToTimeFunction(
+    int n, const Array<IndexedTime> &times) {
+  for (auto t: times) {
+    CHECK(t.value.defined());
+  }
+
+  // Precompute a table that maps a sample index
+  // to the index of an interval between two time stamps.
+  Arrayi idx2ivl = makeIndexToIntervalMap(n, times);
+
+  return [=](int x) {
+    if (x < 0 || n <= x) {
+      return TimeStamp();
+    }
+    int intervalIndex = idx2ivl[x];
+
+    // First, any measurement must be surrounded by a time stamp on either side
+    if (intervalIndex == -1) {
+      return TimeStamp();
+    } else if (intervalIndex == times.size()) {
+      return TimeStamp();
+    }
+
+    auto left = times[intervalIndex];
+    auto right = times[intervalIndex+1];
+
+    // Second, if the measurement is surrounded, the time from one
+    // time stamp to the next should be positive but not longer than, say,
+    // 1 minute or so..
+    if (right.value < left.value) {
+      return TimeStamp();
+    } else if (Duration<double>::minutes(1.0) < right.value - left.value) {
+      return TimeStamp();
+    }
+
+    // The times seem OK, so interpolate based on the index.
+    auto lambda = computeLambda<double>(left.index, right.index, x);
+    auto time = left.value + lambda*(right.value - left.value);
+
+    // But lastly, also check that the timestamp is no older than our first
+    // recordings.
+    return time < TimeStamp::UTC(2008, 1, 1, 1, 1, 1)? TimeStamp() : time;
+  };
+}
+
+LogLoaderNmea0183Parser::LogLoaderNmea0183Parser(
+    LogAccumulator *dst,
+  const std::string &s,
+  bool ignoreWrongChecksum) : _dst(dst), _sourceName(s) {
+  setIgnoreWrongChecksum(ignoreWrongChecksum);
 }
 
 void LogLoaderNmea0183Parser::setProtobufTime(const TimeStamp &time) {
@@ -42,31 +109,34 @@ std::string getDefaultSourceName() {
   return defaultNmea0183SourceName;
 }
 
-void streamToNmeaParser(const std::string &src,
+void streamToNmeaParser(const std::string &nmeaMessage,
     NmeaParser *dstParser,
     Nmea0183LogLoaderAdaptor *adaptor) {
-  for (auto c: src) {
-    Nmea0183ProcessByte(adaptor->sourceName(), c, dstParser, adaptor);
+  for (auto c: nmeaMessage) {
+    Nmea0183ProcessByte(c, dstParser, adaptor);
   }
 }
 
 void streamToNmeaParser(std::istream *src, NmeaParser *dstParser,
     Nmea0183LogLoaderAdaptor *adaptor) {
   while (src->good()) {
-    Nmea0183ProcessByte(adaptor->sourceName(), src->get(), dstParser, adaptor);
+    Nmea0183ProcessByte(src->get(), dstParser, adaptor);
   }
 }
 
 void loadNmea0183Stream(std::istream *stream, LogAccumulator *dst,
-    const std::string &srcName) {
-  LogLoaderNmea0183Parser parser(dst, srcName);
-  Nmea0183LogLoaderAdaptor adaptor(&parser, dst, srcName);
+    const std::string &srcName,
+    const LogLoaderSettings &settings) {
+  LogLoaderNmea0183Parser parser(dst, srcName, settings.ignoreNmea0183Checksum);
+  Nmea0183LogLoaderAdaptor adaptor(&parser);
   streamToNmeaParser(stream, &parser, &adaptor);
+  adaptor.outputTo(srcName, dst);
 }
 
-void loadNmea0183File(const std::string &filename, LogAccumulator *dst) {
+void loadNmea0183File(const std::string &filename, LogAccumulator *dst,
+    const LogLoaderSettings &settings) {
   std::ifstream file(filename);
-  loadNmea0183Stream(&file, dst, defaultNmea0183SourceName);
+  loadNmea0183Stream(&file, dst, defaultNmea0183SourceName, settings);
 }
 
 

--- a/src/server/nautical/logimport/Nmea0183Loader.h
+++ b/src/server/nautical/logimport/Nmea0183Loader.h
@@ -5,41 +5,132 @@
  *      Author: jonas
  */
 
-#ifndef SERVER_NAUTICAL_LOGIMPORT_NMEA0183LOADER_H_
-#define SERVER_NAUTICAL_LOGIMPORT_NMEA0183LOADER_H_
+#ifndef SERVER_NAUTICAL_LOGIMPORT_Nmea0183LOADER_H_
+#define SERVER_NAUTICAL_LOGIMPORT_Nmea0183LOADER_H_
 
 #include <iosfwd>
 #include <server/nautical/logimport/LogAccumulator.h>
 #include <device/Arduino/libraries/NmeaParser/NmeaParser.h>
 #include <server/nautical/logimport/SourceGroup.h>
 #include <string>
+#include <server/common/logging.h>
+#include <server/nautical/logimport/TimeReconstructor.h>
+#include <map>
+#include <vector>
+#include <server/common/ArrayBuilder.h>
+#include <fstream>
+#include <server/nautical/logimport/LogLoaderSettings.h>
 
 namespace sail {
 namespace Nmea0183Loader {
 
-
-
+template <DataCode code>
+struct GetIndexedValues;
 
 template <typename T>
-inline TimeStamp updateLastTime(const TimeStamp &current, const T &candidate) {
-  return current;
-}
+struct Filter {
+  static bool accept(const T &x) {return true;}
+};
 
 template <>
-inline TimeStamp updateLastTime(const TimeStamp &current, const TimeStamp &candidate) {
-  if (!candidate.defined()) {
-    return current;
-  } else if (!current.defined()) {
-    return candidate;
-  }
-  return std::max(current, candidate);
+struct Filter<TimeStamp> {
+  static bool accept(const TimeStamp &x) {return x.defined();}
+};
+
+template <typename T>
+bool acceptNmeaValue(const T &x) {
+  return Filter<T>::accept(x);
 }
 
+// This function is just one possible way to make the function
+// that maps the counter value to a time stamp, see comment below.
+std::function<TimeStamp(int)> makeNmeaIndexToTimeFunction(
+    int n, const Array<IndexedTime> &times);
+
+// Because the Nmea0183 messages don't have timestamps,
+// we assign a counter value to every
+// value received. Then we estimate the time based on the
+// counter values of all measurements.
+// Measurements of type DATE_TIME are special,
+// in the sense that they are used to
+// make a mapping from counter values to time stamps.
+class Nmea0183Reconstructor {
+public:
+  Nmea0183Reconstructor() : _index(0) {}
+
+  template <DataCode code>
+  void addValue(const typename TypeForCode<code>::type &value) {
+    auto &values = GetIndexedValues<code>::apply(this);
+    if (acceptNmeaValue(value)) {
+      values.push_back(makeIndexed(value));
+    }
+  }
+
+  #define MAKE_FIELD(HANDLE, CODE, SHORTNAME, TYPE, DESCRIPTION) \
+    std::vector<IndexedValue<TYPE> > _indexed##HANDLE;
+  FOREACH_CHANNEL(MAKE_FIELD)
+  #undef MAKE_FIELD
+
+  bool reconstructAndOutput(
+      const std::string &sourceName,
+      LogAccumulator *dst,
+      const TimeReconstructorSettings &settings) const {
+    ArrayBuilder<IndexedTime> times;
+    for (auto x: _indexedDATE_TIME) {
+      times.add(x);
+    }
+    auto idx2time = makeNmeaIndexToTimeFunction(_index, times.get());
+    if (!bool(idx2time)) {
+      LOG(ERROR) << "Failed to reconstruct times in Nmea0183 stream";
+      return false;
+    }
+
+#define OUTPUT_ALL_TO_ACC(HANDLE, CODE, SHORTNAME, TYPE, DESCRIPTION) \
+    for (auto x: _indexed##HANDLE) { \
+      auto dstCh = allocateSourceIfNeeded<TYPE>(sourceName, &(dst->_##HANDLE##sources)); \
+      if (isFinite(x.value)) { \
+        auto time = idx2time(x.index); \
+        if (time.defined()) {dstCh->push_back(TimedValue<TYPE>(time, x.value));} \
+      } \
+    }
+FOREACH_CHANNEL(OUTPUT_ALL_TO_ACC)
+#undef OUTPUT_ALL_TO_ACC
+    return true;
+  }
+private:
+  template <typename T>
+  IndexedValue<T> makeIndexed(const T &x) {
+    auto i = _index;
+    _index++;
+    return IndexedValue<T>{i, x};
+  }
+
+  int _index;
+};
+
+template <DataCode code>
+struct GetIndexedValues {
+  static std::vector<IndexedValue<typename TypeForCode<code>::type> >&apply(
+      Nmea0183Reconstructor *x) {
+    static std::vector<IndexedValue<typename TypeForCode<code>::type> > instance;
+    return instance;
+  }
+};
+
+#define SPECIALIZE_GET_INDEXED_VALUES(HANDLE, CODE, SHORTNAME, TYPE, DESCRIPTION) \
+  template <> \
+  struct GetIndexedValues<HANDLE> { \
+    static std::vector<IndexedValue<TYPE> > &apply(Nmea0183Reconstructor *x) { \
+      return x->_indexed##HANDLE; \
+    } \
+  };
+FOREACH_CHANNEL(SPECIALIZE_GET_INDEXED_VALUES)
+#undef SPECIALIZE_GET_INDEXED_VALUES
 
 class LogLoaderNmea0183Parser : public NmeaParser {
 public:
   LogLoaderNmea0183Parser(LogAccumulator *dst,
-      const std::string &s);
+      const std::string &s, bool ignoreWrongChecksum);
   void setProtobufTime(const TimeStamp &time);
 protected:
   void onXDRRudder(const char *senderAndSentence,
@@ -54,32 +145,26 @@ private:
 
 class Nmea0183LogLoaderAdaptor {
  public:
-  Nmea0183LogLoaderAdaptor(NmeaParser *parser, LogAccumulator *dst,
-      const std::string &srcName) :
-    _parser(parser), _sourceName(srcName), _dst(dst) {}
+  Nmea0183LogLoaderAdaptor(
+      NmeaParser *parser) :
+    _parser(parser) {}
 
   template <DataCode Code>
-  void add(const std::string &sourceName, const typename TypeForCode<Code>::type &value) {
-    typedef typename TypeForCode<Code>::type T;
-    typedef typename TimedSampleCollection<T>::TimedVector TimedVector;
-    std::map<std::string, TimedVector> *m = getChannels<Code>(_dst);
-    auto dst = allocateSourceIfNeeded<T>(_sourceName, m);
-    _lastTime = updateLastTime(_lastTime, value);
-    if (_lastTime.defined() && isFinite(value)) {
-      dst->push_back(TimedValue<T>(_lastTime, value));
-    }
+  void add(const NmeaParser &src, const typename TypeForCode<Code>::type &value) {
+    _reconstructor.addValue<Code>(value);
   }
 
   void setTime(const TimeStamp& time) {
-    _lastTime = updateLastTime(_lastTime, time);
+    _reconstructor.addValue<DATE_TIME>(time);
   }
 
-  const std::string &sourceName() const {return _sourceName;}
+  void outputTo(const std::string &srcName, LogAccumulator *dst) const {
+    _reconstructor.reconstructAndOutput(
+        srcName, dst, TimeReconstructorSettings());
+  }
  private:
-  TimeStamp _lastTime;
-  std::string _sourceName;
   NmeaParser *_parser;
-  LogAccumulator *_dst;
+  Nmea0183Reconstructor _reconstructor;
 };
 
 std::string getDefaultSourceName();
@@ -94,12 +179,14 @@ void streamToNmeaParser(std::istream *src, NmeaParser *dstParser,
 void loadNmea0183Stream(
     std::istream *stream,
     LogAccumulator *dst,
-    const std::string &srcName);
+    const std::string &srcName,
+    const LogLoaderSettings &settings);
 
-void loadNmea0183File(const std::string &filename, LogAccumulator *dst);
+void loadNmea0183File(const std::string &filename, LogAccumulator *dst,
+    const LogLoaderSettings &settings);
 
 
 }
 }
 
-#endif /* SERVER_NAUTICAL_LOGIMPORT_NMEA0183LOADER_H_ */
+#endif /* SERVER_NAUTICAL_LOGIMPORT_Nmea0183LOADER_H_ */

--- a/src/server/nautical/logimport/ProtobufLogLoader.h
+++ b/src/server/nautical/logimport/ProtobufLogLoader.h
@@ -9,14 +9,16 @@
 #define SERVER_NAUTICAL_LOGIMPORT_PROTOBUFLOGLOADER_H_
 
 #include <device/anemobox/logger/Logger.h>
+#include <server/nautical/logimport/LogLoaderSettings.h>
 
 namespace sail {
 struct LogAccumulator;
 namespace ProtobufLogLoader {
 
-
-void load(const LogFile &data, LogAccumulator *dst);
-bool load(const std::string &filename, LogAccumulator *dst);
+void load(const LogFile &data, LogAccumulator *dst,
+    const LogLoaderSettings &settings);
+bool load(const std::string &filename, LogAccumulator *dst,
+    const LogLoaderSettings &settings);
 
 }
 } /* namespace sail */

--- a/src/server/nautical/logimport/ProtobufLogTest.cpp
+++ b/src/server/nautical/logimport/ProtobufLogTest.cpp
@@ -7,6 +7,7 @@
 #include <server/common/Env.h>
 #include <server/common/PathBuilder.h>
 #include <server/nautical/logimport/LogLoader.h>
+#include <server/nautical/logimport/ProtobufLogLoader.h>
 #include <device/anemobox/FakeClockDispatcher.h>
 #include <device/anemobox/logger/Logger.h>
 
@@ -24,10 +25,12 @@ TEST(ProtobufLogTest, LoadAFile) {
 }
 
 TEST(ProtobufLogTest, LoadRudderData) {
-  auto data = LogLoader::loadNavDataset(
+  LogLoader loader(LogLoaderSettings::relaxed());
+  loader.load(
       PathBuilder::makeDirectory(Env::SOURCE_DIR)
         .pushDirectory("datasets")
         .pushDirectory("boat55dc89e6838caff0240960a9_rudder").get());
+  auto data = loader.makeNavDataset();
   EXPECT_LT(12/*sufficiently large*/, data.samples<RUDDER_ANGLE>().size());
 }
 

--- a/src/server/nautical/logimport/TimeReconstructor.cpp
+++ b/src/server/nautical/logimport/TimeReconstructor.cpp
@@ -1,0 +1,273 @@
+/*
+ * TimeReconstructor.cpp
+ *
+ *  Created on: Jul 14, 2016
+ *      Author: jonas
+ */
+
+#include <server/nautical/logimport/TimeReconstructor.h>
+#include <server/common/logging.h>
+#include <server/common/LineKM.h>
+#include <server/common/Optional.h>
+#include <server/common/LineKM.h>
+#include <server/math/Majorize.h>
+#include <server/math/QuadForm.h>
+#include <vector>
+#include <server/common/ArrayIO.h>
+#include <server/common/Span.h>
+#include <server/common/ArrayBuilder.h>
+
+namespace sail {
+
+  Optional<LineKM> iterateRobustFit(
+      const Array<IndexedValue<double> > &values,
+      const LineKM &line,
+      const LineFitSettings &settings) {
+    sail::LineFitQF qf = sail::LineFitQF::makeReg(settings.reg);
+    int n = values.size();
+    for (auto v: values) {
+      auto weight =
+          MajQuad::majorizeAbs(v.value - line(v.index), settings.threshold).a;
+      qf += weight*sail::LineFitQF::fitLine(v.index, v.value);
+    }
+    double km[2] = {0, 0};
+    if (!qf.minimize2x1(km)) {
+      LOG(WARNING) << "Failed to minimize quadratic form from "
+          << values.size() << " values starting from " << line;
+      if (n < 30) {
+        std::stringstream ss;
+        for (auto v: values) {
+          ss << "(" << v.index << ", " << v.value << ") ";
+        }
+        LOG(WARNING) << "  The values were " << ss.str();
+      }
+      return Optional<LineKM>();
+    }
+    return LineKM(km[0], km[1]);
+  }
+
+  Optional<LineKM> fitStraightLineRobustly(
+      const LineKM &init,
+      const Array<IndexedValue<double> > &values,
+      const LineFitSettings &settings) {
+    LineKM line = init;
+    for (int i = 0; i < settings.iterations; i++) {
+      auto l = iterateRobustFit(values, line, settings);
+      if (l.defined()) {
+        line = l.get();
+      } else {
+        return Optional<LineKM>();
+      }
+    }
+    return line;
+  }
+
+  Optional<double> initializeSlope(const Array<IndexedValue<double> > &values) {
+    CHECK(2 <= values.size());
+    int preferredStep = 3;
+    int maxStep = values.size() - 1;
+    int step = std::min(preferredStep, maxStep);
+    CHECK(1 <= step);
+    int n = values.size() - step;
+
+    std::vector<double> steps;
+    steps.reserve(n);
+    for (int i = 0; i < n; i++) {
+      auto a = values[i];
+      auto b = values[i+step];
+      auto denom = b.index - a.index;
+      if (denom > 0) {
+        steps.push_back((1.0/denom)*(b.value - a.value));
+      }
+    }
+    if (steps.empty()) {
+      return Optional<double>();
+    }
+
+    auto middle = steps.begin() + n/2;
+    std::nth_element(steps.begin(), middle, steps.end());
+    double slope = *middle;
+    return slope;
+  }
+
+  IndexedTime getMedianTimeStamp(const Array<IndexedTime> &times) {
+    int n = times.size();
+    std::vector<IndexedTime> times2;
+    times2.reserve(n);
+    for (auto x: times) {
+      times2.push_back(x);
+    }
+    assert(times2.size() == times.size());
+    auto middle = times2.begin() + n/2;
+    std::nth_element(times2.begin(), middle, times2.end());
+    return *middle;
+  }
+
+  Span<TimeStamp> validTimes(TimeStamp::UTC(2014, 1, 1, 1, 0, 0),
+
+                             // This is not that nice :-(
+                             TimeStamp::UTC(2034, 1, 1, 1, 0, 0));
+
+  bool allTimesAreValid(const std::vector<TimeStamp> &times) {
+    for (auto t: times) {
+      if (!validTimes.contains(t)) {
+        LOG(ERROR) << "Invalid time: " << t;
+        return false;
+      }
+    }
+    return true;
+  }
+
+
+Array<IndexedTime> makeIndexedTime(const std::vector<TimeStamp> &times) {
+  int n = times.size();
+  Array<IndexedTime> dst(n);
+  for (int i = 0; i < n; i++) {
+    dst[i] = IndexedTime{i, times[i]};
+  }
+  return dst;
+}
+
+Array<IndexedValue<double> > toLocalTimes(const Array<IndexedTime> &times,
+    const IndexedTime &offset) {
+  int n = times.size();
+  ArrayBuilder<IndexedValue<double> > dst;
+  for (auto t: times) {
+    dst.add(IndexedValue<double>{t.index, (t.value - offset.value).seconds()});
+  }
+  return dst.get();
+}
+
+Span<int> getIndexSpan(const Array<IndexedTime> &src) {
+  Span<int> span;
+  for (auto x: src) {
+    span.extend(x.index);
+  }
+  return span;
+}
+
+std::function<TimeStamp(double)> reconstructIndexToTime(
+    const Array<IndexedTime> &indexedTimes,
+    const TimeReconstructorSettings &settings) {
+  if (indexedTimes.size() < 2) {
+    LOG(ERROR) << "Too few samples to reconstruct time";
+    return std::function<TimeStamp(double)>();
+  }
+
+  int n = indexedTimes.size();
+
+  auto median = getMedianTimeStamp(indexedTimes);
+  Array<IndexedValue<double> > local = toLocalTimes(indexedTimes, median);
+
+  auto initSlope0 = initializeSlope(local);
+  if (initSlope0.undefined()) {
+    LOG(ERROR) << "Unable to compute initial slope";
+    return std::function<TimeStamp(double)>();
+  }
+  auto initSlope = initSlope0.get();
+
+  auto initialLineFit = LineKM(initSlope, -initSlope*median.index);
+  auto index2timeSeconds0 = fitStraightLineRobustly(
+      initialLineFit,
+      local, settings.lineFitSettings);
+
+  if (!index2timeSeconds0.defined()) {
+    LOG(ERROR) << "Line fit failed";
+    return std::function<TimeStamp(double)>();
+  }
+  auto index2timeSeconds = index2timeSeconds0.get();
+  auto samplingPeriod = Duration<double>::seconds(index2timeSeconds.getK());
+
+  if (!settings.validSamplingPeriods.contains(samplingPeriod)) {
+    LOG(ERROR) << "Fitted sampling period "
+        << samplingPeriod.seconds() << " seconds out of bounds";
+    return std::function<TimeStamp(double)>();
+  }
+
+  auto f = [=](double index) {
+    return median.value + Duration<double>::seconds(index2timeSeconds(index));
+  };
+
+  auto indexSpan = getIndexSpan(indexedTimes);
+  if (!settings.validTimes.contains(f(indexSpan.minv()))
+      || !settings.validTimes.contains(f(indexSpan.maxv()))) {
+    LOG(ERROR) << "Mapped times out of range";
+    return std::function<TimeStamp(double)>();
+  }
+
+  return f;
+}
+
+std::function<TimeStamp(double)> reconstructIndexToTimeOrConstant(
+    const Array<IndexedTime> &indexedTimes,
+    const TimeReconstructorSettings &settings) {
+  if (indexedTimes.empty()) {
+    LOG(ERROR) << "No samples from which to reconstruct time";
+    return std::function<TimeStamp(double)>();
+  } else if (indexedTimes.size() == 1) {
+    return [=](double) {
+      return indexedTimes[0].value;
+    };
+  } else {
+    return reconstructIndexToTime(indexedTimes, settings);
+  }
+}
+
+
+Array<IndexedTime> reconstructTime(const Array<IndexedTime> &times,
+    const TimeReconstructorSettings &settings) {
+  int n = times.size();
+  ArrayBuilder<IndexedTime> dst;
+
+  auto index2time = reconstructIndexToTime(times, settings);
+  if (!index2time) {
+    LOG(ERROR) << "Failed to reconstruct times because no function was fitted";
+    return Array<IndexedTime>();
+  }
+
+  int badCounter = 0;
+
+  for (auto x: times) {
+    auto predicted = index2time(x.index);
+    if (!settings.validTimes.contains(predicted)) {
+      LOG(ERROR) << "The reconstructed time function maps to invalid times";
+      return Array<IndexedTime>();
+    }
+    auto gap = fabs(x.value - predicted);
+    if (settings.maxGap < gap) {
+      badCounter++;
+      dst.add(IndexedTime{x.index, predicted});
+    } else {
+      dst.add(x);
+    }
+  }
+
+  if (0 < badCounter) {
+    LOG(WARNING) << "When loading some log file, " << badCounter <<
+        " of " << n <<
+        " times for some channel were really bad and had to be adjusted.";
+  }
+  if (settings.maxRelativeBadCount*n < badCounter) {
+    LOG(ERROR) << "In fact, the proportion of bad samples is unacceptable.";
+    return Array<IndexedTime>();
+  }
+
+  return dst.get();
+}
+
+bool regularizeTimesInPlace(std::vector<TimeStamp> *times,
+    const TimeReconstructorSettings &settings) {
+  auto reconstructed = reconstructTime(makeIndexedTime(*times), settings);
+  if (reconstructed.empty()) {
+    return false;
+  } else {
+    CHECK(reconstructed.size() == times->size());
+    for (auto x: reconstructed) {
+      CHECK(x.index < times->size());
+      (*times)[x.index] = x.value;
+    }
+    return true;
+  }
+}
+
+}

--- a/src/server/nautical/logimport/TimeReconstructor.h
+++ b/src/server/nautical/logimport/TimeReconstructor.h
@@ -1,0 +1,70 @@
+/*
+ * TimeReconstructor.h
+ *
+ *  Created on: Jul 14, 2016
+ *      Author: jonas
+ */
+
+#ifndef SERVER_NAUTICAL_LOGIMPORT_TIMERECONSTRUCTOR_H_
+#define SERVER_NAUTICAL_LOGIMPORT_TIMERECONSTRUCTOR_H_
+
+#include <server/common/TimeStamp.h>
+#include <functional>
+#include <server/common/Span.h>
+#include <device/Arduino/libraries/PhysicalQuantity/PhysicalQuantity.h>
+
+namespace sail {
+
+struct LineFitSettings {
+    int iterations = 4;
+    double threshold = 1.0e-9;
+    double reg = 1.0e-12;
+  };
+
+struct TimeReconstructorSettings {
+  LineFitSettings lineFitSettings;
+
+  Span<Duration<double> > validSamplingPeriods = Span<Duration<double> >(
+      Duration<double>::seconds(0.001),
+      Duration<double>::seconds(60));
+
+  Span<TimeStamp> validTimes = Span<TimeStamp>(
+      TimeStamp::UTC(2007, 1, 1, 1, 1, 1),
+      TimeStamp::UTC(2094, 1, 1, 1, 1, 1)
+      );
+
+  Duration<double> maxGap = Duration<double>::minutes(5.0);
+
+  double maxRelativeBadCount = 0.2;
+};
+
+template <typename T>
+struct IndexedValue {
+  int index;
+  T value;
+  bool operator<(const IndexedValue<T> &other) const {
+    return value < other.value;
+  }
+};
+
+typedef IndexedValue<TimeStamp> IndexedTime;
+
+std::function<TimeStamp(double)> reconstructIndexToTime(
+    const Array<IndexedTime> &indexedTimes,
+    const TimeReconstructorSettings &settings = TimeReconstructorSettings());
+
+std::function<TimeStamp(double)> reconstructIndexToTimeOrConstant(
+    const Array<IndexedTime> &indexedTimes,
+    const TimeReconstructorSettings &settings = TimeReconstructorSettings());
+
+Array<IndexedTime> reconstructTime(
+    const Array<IndexedTime> &times,
+    const TimeReconstructorSettings &settings = TimeReconstructorSettings());
+
+bool regularizeTimesInPlace(std::vector<TimeStamp> *times,
+    const TimeReconstructorSettings &settings = TimeReconstructorSettings());
+
+
+}
+
+#endif /* SERVER_NAUTICAL_LOGIMPORT_TIMERECONSTRUCTOR_H_ */

--- a/src/server/nautical/logimport/TimeReconstructorTest.cpp
+++ b/src/server/nautical/logimport/TimeReconstructorTest.cpp
@@ -1,0 +1,39 @@
+/*
+ * TimeReconstructorTest.cpp
+ *
+ *  Created on: Jul 14, 2016
+ *      Author: jonas
+ */
+
+#include <gtest/gtest.h>
+#include <server/nautical/logimport/TimeReconstructor.h>
+
+using namespace sail;
+
+namespace {
+  TimeStamp indexToTime(int index) {
+    return TimeStamp::UTC(2016, 7, 13, 19, 22, 0) + double(index)*Duration<double>::seconds(2.4);
+  }
+}
+
+TEST(LoggerTest, RegularizeTimeInPlace) {
+  auto s = Duration<double>::seconds(1.0);
+
+
+  int n = 12;
+  std::vector<TimeStamp> times;
+  for (int i = 0; i < n; i++) {
+    times.push_back(indexToTime(i));
+  }
+
+  // Bad times:
+  times[0] = TimeStamp::UTC(2070, 5, 4, 19, 22, 0);
+  times[4] = TimeStamp::UTC(2048, 5, 4, 19, 22, 0);
+
+  EXPECT_TRUE(regularizeTimesInPlace(&times));
+
+  for (int i = 0; i < n; i++) {
+    auto diff = times[i] - indexToTime(i);
+    EXPECT_NEAR(diff.seconds(), 0.0, 0.001);
+  }
+}


### PR DESCRIPTION
This PR attempts to clean up times when loading log files. 
- For regular log files (our protobuf format), we assume that for the times y, there is a function y = f(x) = k*x + m, that maps an index x to time y. We find that function, and adjust all values y that don't fit well with it.
- For NMEA0183 data, we have some heuristic tests to estimate the time of every value, and we reject values for which we believe the time is very inaccurate.

This seems to fix the issues with Raijin, when I run it I only get sessions for 2015 and 2016, which is what we want, right?
