### PR TITLE
Reuse merged channels

### DIFF
--- a/src/server/nautical/NavDataset.cpp
+++ b/src/server/nautical/NavDataset.cpp
@@ -274,9 +274,10 @@ NavDataset NavDataset::stripChannel(DataCode code) const {
   return NavDataset(
       cloneAndfilterDispatcher(
           _dispatcher.get(),
-          [code](DataCode testedCode, const std::string&) { return testedCode != code; }
-          ),
-      std::make_shared<std::map<DataCode, std::shared_ptr<DispatchData> > >(),
+          [code](DataCode testedCode, const std::string&) {
+            return testedCode != code;
+          }),
+      resetMergedChannels(_merged, std::set<DataCode>{code}),
       _lowerBound,
       _upperBound);
 }


### PR DESCRIPTION
It looks like the peak memory consumption for the Irene dataset with these changes is about 7 GB whereas it is more than 11 GB with the master branch. But there might still be memory waste in other parts of the program too.
