### PR TITLE
Remove code that we don't seem to need

### DIFF
--- a/src/server/nautical/tiles/TileUtils.cpp
+++ b/src/server/nautical/tiles/TileUtils.cpp
@@ -21,11 +21,6 @@ using namespace sail::NavCompat;
 namespace {
 
 NavDataset filterNavs(NavDataset navs) {
-  if (!isValid(navs.dispatcher().get())) {
-    LOG(FATAL) << "Called with invalid dispatcher, please fix the code calling this function";
-    return NavDataset();
-  }
-
   auto results = filterGpsData(navs);
   if (results.empty()) {
     LOG(ERROR) << "GPS filtering failed";


### PR DESCRIPTION
We saw in the profiler that this code takes about 49 percents of the total time. Maybe we can remove it to save time?
