### PR TITLE
Optimize SimulateBox; clears TWDIR and TARGET_VMG on simulate

### DIFF
--- a/src/device/anemobox/anemonode/components/estimator.js
+++ b/src/device/anemobox/anemonode/components/estimator.js
@@ -15,6 +15,7 @@ function loadCalib(path) {
 }
 
 function start() {
+  // This list should match the one in SimulateBox.cpp
   var triggeringFields =
     ['awa', 'aws', 'gpsSpeed', 'gpsBearing', 'watSpeed', 'magHdg'];
 

--- a/src/device/anemobox/simulator/CMakeLists.txt
+++ b/src/device/anemobox/simulator/CMakeLists.txt
@@ -13,5 +13,5 @@ cxx_test(anemobox_SimulateBoxTest
   SimulateBoxTest.cpp
   gtest_main
   anemobox_SimulateBox
-  anemobox_DispatcherUtils
+  calib_Calibrator
   )

--- a/src/device/anemobox/simulator/SimulateBox.h
+++ b/src/device/anemobox/simulator/SimulateBox.h
@@ -9,17 +9,6 @@
 
 namespace sail {
 
-// CB is called whenever the true wind estimator should 
-// compute a publish a value.
-class ReplayDispatcher;
-void replayDispatcherTrueWindEstimator(Dispatcher *src,
-                                       ReplayDispatcher *replay, 
-                                       std::function<void()> cb);
-
-void generateComputeCallbacks(Dispatcher *src,
-    ReplayDispatcher *replay,
-    std::function<void()> cb);
-
 NavDataset SimulateBox(const std::string& boatDat, const NavDataset &ds);
 NavDataset SimulateBox(std::istream& boatDat, const NavDataset &ds);
 

--- a/src/device/anemobox/simulator/SimulateBoxTest.cpp
+++ b/src/device/anemobox/simulator/SimulateBoxTest.cpp
@@ -1,13 +1,13 @@
 #include <gtest/gtest.h>
 #include <device/anemobox/simulator/SimulateBox.h>
-#include <device/anemobox/DispatcherUtils.h>
+#include <server/nautical/calib/Calibrator.h>
 
 using namespace sail;
 
 namespace {
 
   template <typename T>
-  void pt(ReplayDispatcher *dst, DataCode c, Duration<double> localTime, T x) {
+  void pt(std::shared_ptr<ReplayDispatcher> dst, DataCode c, Duration<double> localTime, T x) {
     auto start = TimeStamp::UTC(2016, 3, 24, 18, 10, 0);
     const char *name = "test";
     TimeStamp t = start + localTime;
@@ -24,7 +24,9 @@ namespace {
 // when we are doing a replay.
 TEST(SimulateBox, Replay) {
 
-  ReplayDispatcher d;
+  
+  std::shared_ptr<ReplayDispatcher> rd = std::make_shared<ReplayDispatcher>();
+  NavDataset original(std::static_pointer_cast<Dispatcher>(rd));
 
   /*    AWA, AWS, GPS_SPEED, GPS_BEARING,
       WAT_SPEED, MAG_HEADING*/
@@ -36,44 +38,39 @@ TEST(SimulateBox, Replay) {
   typedef Velocity<double> V;
 
   // First a dense batch of values.
-  pt<A>(&d, AWA, 0.0*ms, 3.0*degrees); // Compute first triggered here to occur at 20 ms from now.
-  pt<V>(&d, AWS, 1.0*ms, 12.0*knots);
-  pt<V>(&d, GPS_SPEED, 2.0*ms, 4.0*knots);
-  pt<A>(&d, GPS_BEARING, 3.0*ms, 34.0*degrees);
-  pt<V>(&d, WAT_SPEED, 4.0*ms, 4.0*knots);
-  pt<A>(&d, MAG_HEADING, 4.0*ms, 35.0*degrees);
-  pt<A>(&d, AWA, 4.0*ms, 3.0*degrees);
-  pt<V>(&d, AWS, 5.0*ms, 12.0*knots);
-  pt<V>(&d, GPS_SPEED, 5.0*ms, 4.0*knots);
-  pt<A>(&d, GPS_BEARING, 5.0*ms, 34.0*degrees);
-  pt<V>(&d, WAT_SPEED, 6.0*ms, 4.0*knots);
-  pt<A>(&d, MAG_HEADING, 7.0*ms, 35.0*degrees);
+  pt<A>(rd, AWA, 0.0*ms, 3.0*degrees); // Compute first triggered here to occur at 20 ms from now.
+  pt<V>(rd, AWS, 1.0*ms, 12.0*knots);
+  pt<V>(rd, GPS_SPEED, 2.0*ms, 4.0*knots);
+  pt<A>(rd, GPS_BEARING, 3.0*ms, 34.0*degrees);
+  pt<V>(rd, WAT_SPEED, 4.0*ms, 4.0*knots);
+  pt<A>(rd, MAG_HEADING, 4.0*ms, 35.0*degrees);
+  pt<A>(rd, AWA, 4.0*ms, 3.0*degrees);
+  pt<V>(rd, AWS, 5.0*ms, 12.0*knots);
+  pt<V>(rd, GPS_SPEED, 5.0*ms, 4.0*knots);
+  pt<A>(rd, GPS_BEARING, 5.0*ms, 34.0*degrees);
+  pt<V>(rd, WAT_SPEED, 6.0*ms, 4.0*knots);
+  pt<A>(rd, MAG_HEADING, 7.0*ms, 35.0*degrees);
 
   // Compute will be called here, at 20 ms
 
   // Gap of 3000 - 7 ms = 2993 ms
 
-  pt<A>(&d, AWA, 3000.0*ms, 3.0*degrees); // <-- 13th value. Schedule compute at 3020 ms
+  pt<A>(rd, AWA, 3000.0*ms, 3.0*degrees); // <-- 13th value. Schedule compute at 3020 ms
 
   // This is a stack of the number of values that the destination dispatcher
   // will contain when it is called. So for the first call, it will contain 12
   // values, and for the second call it will contain 13.
   std::vector<int> expectedCounts{13, 12};
 
+  // Let's create a default calibration to allow the true wind estimator
+  // to do its job.
+  std::stringstream calibFile;
+  Calibrator calibrator;
+  calibrator.saveCalibration(&calibFile);
+  calibFile.seekg(0, std::ios::beg);
 
-  ReplayDispatcher d2;
+  NavDataset simulated = SimulateBox(calibFile, original);
 
-  generateComputeCallbacks(&d,
-
-      // Should compute the true wind, in reality.
-      &d2, [&]() {
-    EXPECT_FALSE(expectedCounts.empty());
-    auto e = expectedCounts.back();
-    expectedCounts.pop_back();
-    EXPECT_EQ(e, countValues(&d2));
-  });
-
-  EXPECT_TRUE(expectedCounts.empty());
-
-  EXPECT_TRUE(true);
+  EXPECT_EQ(0, original.samples<TWDIR>().size());
+  EXPECT_EQ(1, simulated.samples<TWDIR>().size());
 }

--- a/src/server/nautical/calib/CMakeLists.txt
+++ b/src/server/nautical/calib/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(calib_Calibrator
                       anemobox_SimulateBox
                       common_Histogram
                       common_math
+                      logimport_LogLoader
                       nautical_FlowErrors
                       nautical_downsamplegps
                       nautical_grammars_WindOrientedGrammar


### PR DESCRIPTION
SimulateBox now replace TWDIR and TARGET_VMG channels with
newly computed data, making sure not to mix old and new data.

Optimize simulation code for speed.
