### PR TITLE
Improve maneuver rejection and logging in Calibrator

### DIFF
--- a/src/server/nautical/Nav.cpp
+++ b/src/server/nautical/Nav.cpp
@@ -87,6 +87,19 @@ Angle<double> Nav::bestTwaEstimate() const {
   return Angle<>();
 }
 
+Velocity<double> Nav::bestTwsEstimate() const {
+  if (hasTrueWindOverGround()) {
+    return calcTws(trueWindOverGround());
+  }
+  if (hasExternalTrueWind()) {
+    return externalTws();
+  }
+  if (hasApparentWind()) {
+    return calcTws(estimateTrueWind());
+  }
+  return Velocity<>();
+}
+
 std::ostream &operator<<(std::ostream &s, const Nav &x) {
   s << "Nav:\n";
   s << "  time: " << x.time() << "\n";

--- a/src/server/nautical/Nav.h
+++ b/src/server/nautical/Nav.h
@@ -135,6 +135,7 @@ class Nav {
   // very accurate.
   HorizontalMotion<double> estimateTrueWind() const;
   Angle<double> bestTwaEstimate() const;
+  Velocity<double> bestTwsEstimate() const;
 
  private:
   enum {


### PR DESCRIPTION
- low wind reject based on TWS instead of AWS
- reject if GPS speed < .5kn
- improve logging if _verbose is set
