### PR TITLE
Update gtest installation

### DIFF
--- a/cmake/GTest.cmake
+++ b/cmake/GTest.cmake
@@ -3,38 +3,23 @@
 
 include(ExternalProject)
 
-option(USE_GMOCK "If ON, not only gtest, but also gmock will be installed." ON)
+ExternalProject_Add(gtest_ext
+        URL "https://github.com/google/googletest/archive/release-1.8.0.zip"
+        BINARY_DIR "${CMAKE_BINARY_DIR}/third-party/gmock-build"
+        SOURCE_DIR "${CMAKE_BINARY_DIR}/third-party/gmock-src"
+        CMAKE_ARGS "${gtest_cmake_args}"
+          "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+        INSTALL_COMMAND ""
+            )
+set(GTEST_INCLUDE_DIRS
+    "${CMAKE_BINARY_DIR}/third-party/gmock-src/googlemock/include"
+    "${CMAKE_BINARY_DIR}/third-party/gmock-src/googletest/include"
+   )
+link_directories(
+    "${CMAKE_BINARY_DIR}/third-party/gmock-build/googlemock"
+    "${CMAKE_BINARY_DIR}/third-party/gmock-build/googlemock/gtest"
+    )
 
-if (USE_GMOCK)
-  ExternalProject_Add(gtest_ext
-          URL "https://googlemock.googlecode.com/files/gmock-1.7.0.zip"
-          BINARY_DIR "${CMAKE_BINARY_DIR}/third-party/gmock-build"
-          SOURCE_DIR "${CMAKE_BINARY_DIR}/third-party/gmock-src"
-          CMAKE_ARGS "${gtest_cmake_args}"
-            "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
-          INSTALL_COMMAND ""
-              )
-  set(GTEST_INCLUDE_DIRS
-                   "${CMAKE_BINARY_DIR}/third-party/gmock-src/gtest/include"
-                   "${CMAKE_BINARY_DIR}/third-party/gmock-src/include"
-     )
-  link_directories(
-      "${CMAKE_BINARY_DIR}/third-party/gmock-build"
-      "${CMAKE_BINARY_DIR}/third-party/gmock-build/gtest"
-      )
-else (USE_GMOCK)
-  ExternalProject_Add(gtest_ext
-          SVN_REPOSITORY "http://googletest.googlecode.com/svn/tags/release-1.7.0"
-          BINARY_DIR "${CMAKE_BINARY_DIR}/third-party/gtest-build"
-          SOURCE_DIR "${CMAKE_BINARY_DIR}/third-party/gtest-src"
-          INSTALL_COMMAND ""
-          CMAKE_ARGS "${gtest_cmake_args}"
-            "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
-          )
-  set(GTEST_INCLUDE_DIRS
-          "${CMAKE_BINARY_DIR}/third-party/gtest-src/include"
-     )
-endif (USE_GMOCK)
 
 enable_testing()
 

--- a/src/server/common/HistogramTest.cpp
+++ b/src/server/common/HistogramTest.cpp
@@ -68,8 +68,7 @@ TEST(HistogramTest, Undefined) {
 
   const int count = 7;
   double anglesDeg[count] = {576.2019, 102.1582, 303.6681, 659.3296, 570.3893, 690.8345, 472.1333};
-  Array<Angle<double> > angles = toArray(
-      map(Arrayd(count, anglesDeg), [&](double x) {return Angle<double>::degrees(x);}));
+  Array<Angle<double> > angles = toArray(sail::map(Arrayd(count, anglesDeg), [&](double x) {return Angle<double>::degrees(x);}));
 
   int bins[count] = {1, 0, 2, 2, 1, 2, 0};
   Arrayi estBins = hmap.assignBins(angles);
@@ -86,8 +85,7 @@ TEST(HistogramTest, Undefined) {
   EXPECT_EQ(hmap.periodicIndex(-1), 2);
   EXPECT_EQ(hmap.periodicIndex(-4), 2);
 
-  MDArray2d plotdata = hmap.makePolarPlotData(
-      toArray(map(hist, [&](int x) {return double(x);})), true);
+  MDArray2d plotdata = hmap.makePolarPlotData(toArray(sail::map(hist, [&](int x) {return double(x);})), true);
   LineKM rowmap(0, 360, 0.0, plotdata.rows());
   MDArray2d A = plotdata.sliceRow(int(round(rowmap(60))));
   MDArray2d B = plotdata.sliceRow(int(round(rowmap(300))));


### PR DESCRIPTION
This is not urgent, no need to review it in the WE :-)

I updated the installation script for GTest.

What is the reason for having GMock being optional? I dropped that optionality. Also I ran into an unrelated compilation error related to naming ambiguity, that I fixed.
