### PR TITLE
Protect the endpoint database with a mutex

### DIFF
--- a/nodemodules/endpoint/largepacket.js
+++ b/nodemodules/endpoint/largepacket.js
@@ -156,7 +156,7 @@ function sendPacket(localEndpoint, dst, label, data, settings, cb) {
 }
 
 function handleFirstPacket(endpoint, packet) {
-  ep.withTransaction(endpoint.db, function(T, cb) {
+  endpoint.withDB(function(T, cb) {
     ep.storePacket(T, packet, cb);
   }, function(err) {
     if (err) {
@@ -292,7 +292,7 @@ function attemptToAssemblePacket(T, endpoint, lastPacket, cb) {
 }
 
 function handleRemainingPacket(endpoint, packet) {
-  ep.withTransaction(endpoint.db, function(T, cb) {
+  endpoint.withDB(function(T, cb) {
     ep.storePacket(T, packet, function(err) {
       if (err) {
         cb(err);

--- a/nodemodules/endpoint/package.json
+++ b/nodemodules/endpoint/package.json
@@ -9,9 +9,10 @@
   "author": "",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "async": "~0.9.0",
+    "async": "~2.0.1",
     "deep-equal-ident": "^1.0.0",
     "json-buffer": "^2.0.11",
+    "locks": "^0.2.2",
     "mangler": "file:../mangler",
     "mkdirp": "^0.5.1",
     "msgpack-js": "^0.3.0",


### PR DESCRIPTION
This PR adds a method `.withDB` to the `Endpoint` class in `endpoint.sqlite.js` that will provide exclusive access to the sqlite database instance. It also renames the `.db` field to `.dbPrivateInstance` so that it will be less tempting to access it directly instead of through the `withDB` method. 

My hope with this PR is that it will address possible synchronization problems. In particular, I noticed the line `data.close.callDelayed(closeTimeoutMillis);` in `LocalEndpoint.js` which will close the sqlite database of an endpoint after 30 seconds. That would be problematic, if there is a long-running synchronization operation taking places while the database is concurrently closed, as discussed here: https://github.com/jpilet/anemomind/issues/870#issuecomment-251897407

With the changes of this PR, access to the database is always mutually exclusive (at least within the same Node process) as long as it is accessed using the `.withDB` or `.withRawDB`. The use of locks also increases the risk of deadlocks, but I guess we have to live with that :-) 
