### PR TITLE
Add a better command-line parser

### DIFF
--- a/src/server/common/Array.h
+++ b/src/server/common/Array.h
@@ -300,7 +300,6 @@ class Array {
     assert(to <= _size);
 #endif
     if (empty()) {
-      assert(_data == nullptr);
       return ThisType();
     }
     return Array(_data + from, to - from, _storage);

--- a/src/server/common/CMakeLists.txt
+++ b/src/server/common/CMakeLists.txt
@@ -417,3 +417,18 @@ target_depends_on_poco_xml(common_DOMUtils)
 target_link_libraries(common_DOMUtils
   common_PathBuilder
   )
+
+add_library(common_CmdArg
+  CmdArg.h
+  CmdArg.cpp
+  )
+
+target_link_libraries(common_CmdArg
+  common_logging
+  )
+
+cxx_test(common_CmdArgTest
+  CmdArgTest.cpp
+  gtest_main
+  common_CmdArg
+  )

--- a/src/server/common/CmdArg.cpp
+++ b/src/server/common/CmdArg.cpp
@@ -1,0 +1,406 @@
+/*
+ * CmdArg.cpp
+ *
+ *  Created on: 20 Oct 2016
+ *      Author: jonas
+ */
+
+#include <server/common/logging.h>
+#include <iostream>
+#include <server/common/CmdArg.h>
+
+namespace sail {
+namespace CmdArg {
+
+
+class FailedToParseArgument : public std::exception {
+public:
+  FailedToParseArgument(const std::string &r) : _reason(r),
+    _what("FailedToParseArgument: " + r) {}
+  const char* what() const noexcept {
+    return _what.c_str();
+  }
+private:
+  std::string _reason, _what;
+};
+
+template <typename T>
+struct ParseArgument {
+  static const char *type() {return "unknown type";}
+
+  static T apply(const std::string &input) {
+    throw FailedToParseArgument("Unknown type");
+    return T();
+  }
+};
+
+// TODO: Do something nice that will
+// work with any integer, not just 'int'
+template <>
+struct ParseArgument<int> {
+  static const char *type() {return "int";}
+
+  static int apply(const std::string &input) {
+    return std::stoi(input);
+  }
+};
+
+template <>
+struct ParseArgument<double> {
+  static const char *type() {return "double";}
+
+  static double apply(const std::string &input) {
+    return std::stod(input);
+  }
+};
+
+template <>
+struct ParseArgument<std::string> {
+  static const char *type() {return "string";}
+
+  static std::string apply(const std::string &input) {
+    return input;
+  }
+};
+
+template <>
+struct ParseArgument<bool> {
+  static const char *type() {return "bool";}
+
+  static bool apply(const std::string &input) {
+    if (input == "true" || input == "on" || input == "1"
+        || input == "enabled" || input == "enable") {
+      return true;
+    } else if (input == "false" || input == "off" || input == "0"
+        || input == "disabled" || input == "disable") {
+      return false;
+    }
+
+    throw FailedToParseArgument(
+        "'"+input+"' cannot be interpreted as a boolean.");
+
+    return false;
+  }
+};
+
+template <>
+struct ParseArgument<char> {
+  static const char *type() {return "char";}
+
+  static char apply(
+      const std::string &input) {
+    if (input.size() == 1) {
+      return input[0];
+    } else {
+      throw FailedToParseArgument("'" + input + "' is not a character");
+    }
+    return '_';
+  }
+};
+
+
+template <typename T>
+Arg<T> &Arg<T>::describe(const std::string &d) {
+  _desc = d;
+  return *this;
+}
+
+bool isFlag(const std::string v) {
+  if (v.size() < 2) {
+    return false;
+  }
+  return v[0] == '-';
+}
+
+template <typename T> struct IsString {static const bool value = false;};
+template <> struct IsString<std::string> {static const bool value = true;};
+
+template <typename T>
+T Arg<T>::parseAndProceed(std::string **s) const {
+  auto v = **s;
+  if (!_acceptFlags && IsString<T>::value && isFlag(v)) {
+    throw FailedToParseArgument(
+        "Tried to pass flag '"+v+"' as an argument");
+  }
+  (*s)++;
+  return ParseArgument<T>::apply(v);
+}
+
+template <typename T>
+Arg<T> &Arg<T>::dontRejectFlags() {
+  _acceptFlags = true;
+  return *this;
+}
+
+template <typename T>
+std::string Arg<T>::description() const {
+  return _name + " [" + ParseArgument<T>::type() + "]: " + _desc;
+}
+
+template <typename T>
+ArgSpec Arg<T>::spec() const {
+  ArgSpec s;
+  s.name = _name;
+  s.type = ParseArgument<T>::type();
+  s.desc = _desc;
+  return s;
+}
+
+template class Arg<int>;
+template class Arg<double>;
+template class Arg<std::string>;
+template class Arg<bool>;
+template class Arg<char>;
+
+
+Result InputForm::parse(
+    const Array<std::string> &remainingArgs) const {
+  return _handler(remainingArgs);
+}
+
+InputForm &InputForm::describe(const std::string &d) {
+  _desc = d;
+  return *this;
+}
+
+void indent(int depth, std::ostream *dst) {
+  for (int i = 0; i < depth; i++) {
+    *dst << "  ";
+  }
+}
+
+
+void InputForm::outputHelp(int depth, std::ostream *dst) const {
+  indent(depth, dst);
+  *dst << "Format: " << _desc << "\n";
+  if (_argSpecs.empty()) {
+    indent(depth, dst);
+    *dst << "  (no arguments)\n";
+  } else {
+    for (auto spec: _argSpecs) {
+      indent(depth, dst);
+      *dst << "  * [" << spec.name << " : " << spec.type << "]";
+      if (!spec.desc.empty()) {
+        *dst << ": " << spec.desc;
+      }
+      *dst << "\n";
+    }
+    *dst << "\n";
+  }
+}
+
+Entry::Entry(
+    const Array<std::string> &commands,
+    const Array<InputForm> &forms) :
+        _commands(commands),
+        _forms(forms) {}
+
+Entry &Entry::describe(const std::string &d) {
+  _description = d;
+  return *this;
+}
+
+bool Entry::parse(
+    std::vector<Result> *failureReasons,
+    Array<std::string> *remainingArgsInOut) {
+
+  _callCount++;
+  if (_maxCount < _callCount) {
+    failureReasons->push_back(Result::failure("Called too many times"));
+    return false;
+  }
+
+  for (auto f: _forms) {
+    auto result = f.parse(*remainingArgsInOut);
+    if (result.succeeded()) {
+      *remainingArgsInOut = remainingArgsInOut->sliceFrom(
+          f.argCount());
+      return true;
+    } else {
+      // TODO: Append metadata (such as which form failed to the result)
+      failureReasons->push_back(result);
+    }
+  }
+  return false;
+}
+
+const Array<std::string> &Entry::commands() const {
+  return _commands;
+}
+
+void Entry::outputHelp(int depth, std::ostream *dst) const {
+  indent(depth, dst);
+  for (auto x: _commands) {
+    *dst << x << " ";
+  }
+  *dst << ":\n";
+  indent(depth, dst);
+  *dst << "  " << _description << "\n\n";
+  for (auto frm: _forms) {
+    frm.outputHelp(depth + 2, dst);
+  }
+  *dst << "\n";
+}
+
+Entry &Entry::required() {
+  setMinCount(1);
+  return *this;
+}
+
+Entry &Entry::setMinCount(int n) {
+  _minCount = n;
+  _maxCount = std::max(_minCount, _maxCount);
+  return *this;
+}
+
+std::string Entry::callSpec() const {
+  std::stringstream ss;
+  for (auto c: _commands) {
+    ss << c << " ";
+  }
+  return ss.str();
+}
+
+Entry &Entry::setMaxCount(int n) {
+  _maxCount = n;
+  _minCount = std::min(_minCount, _maxCount);
+  return *this;
+}
+
+Result Entry::checkCallCount() const {
+  if (_callCount < _minCount) {
+    std::stringstream msg;
+    msg << callSpec() << ": Called too few times ("
+        << _callCount << ") but should be called at least "
+        << _minCount << " times.";
+    return Result::failure(msg.str());
+  } else if (_maxCount < _callCount) {
+    std::stringstream msg;
+    msg << callSpec() << ": Called too many times ("
+        << _callCount << ") but should be called at most "
+        << _maxCount << " times";
+    return Result::failure(msg.str());
+  }
+  return Result::success();
+}
+
+
+Entry &Parser::bind(
+    const Array<std::string> &commands,
+    const Array<InputForm> &inputForms) {
+  CHECK(!_initialized);
+  return addAndRegisterEntry(std::make_shared<Entry>(
+      commands, inputForms));
+}
+
+Entry::Ptr Parser::addEntry(const Entry::Ptr &e0) {
+  _entries.push_back(e0);
+  return e0;
+}
+
+Entry &Parser::addAndRegisterEntry(const Entry::Ptr &e0) {
+  auto e = addEntry(e0);
+  for (auto cmd: e0->commands()) {
+    CHECK(_map.count(cmd) == 0);
+    _map[cmd] = e;
+  }
+  return *e;
+}
+
+void Parser::displayHelpMessage() {
+  std::cout << _description << "\n\n";
+
+  for (auto e: _entries) {
+    e->outputHelp(1, &std::cout);
+  }
+
+  _helpDisplayed = true;
+}
+
+void Parser::initialize() {
+  CHECK(!_initialized);
+  auto frm = inputForm([this]() {
+              displayHelpMessage();
+              return true;
+            });
+  auto hcmds = Array<std::string>{"-h", "--help"};
+  Array<InputForm> frms{
+            frm
+        };
+  auto e = addEntry(std::make_shared<Entry>(
+      hcmds, frms));
+  e->describe("Display help message");
+  for (auto h: hcmds) {
+    _map[h] = e;
+  }
+  _initialized = true;
+}
+
+namespace {
+  Array<std::string> wrapArgs(int argc, const char **argv) {
+    Array<std::string> dst(argc-1);
+    for (int i = 1; i < argc; i++) {
+      dst[i-1] = argv[i];
+    }
+    return dst;
+  }
+}
+
+
+Parser::Status Parser::parse(int argc, const char **argv) {
+  CHECK(!_initialized);
+  initialize();
+  CHECK(_initialized);
+  auto args = wrapArgs(argc, argv);
+  while (!args.empty()) {
+    auto first = args[0];
+    args = args.sliceFrom(1);
+    auto f = _map.find(first);
+    _helpDisplayed = false;
+    if (f == _map.end()) {
+      _freeArgs.push_back(first);
+    } else {
+      std::vector<Result> reasons;
+      if (!f->second->parse(&reasons, &args)) {
+        std::cout << "Failed to parse command "
+            << first << " because of one of these reasons:\n";
+        for (auto r: reasons) {
+          std::cout << "  * " << r.toString() << std::endl;
+        }
+        return Parser::Status::Error;
+      }
+    }
+    if (_helpDisplayed) {
+      return Parser::Status::Done;
+    }
+  }
+
+  for (auto e: _entries) {
+    auto result = e->checkCallCount();
+    if (result.failed()) {
+      std::cout << "Wrong number of calls:\n";
+      std::cout << result.toString() << std::endl;
+      return Parser::Status::Error;
+    }
+  }
+
+  return Parser::Status::Continue;
+}
+
+
+Parser::Parser(const std::string &desc) :
+    _description(desc),
+    _initialized(false),
+    _helpDisplayed(false) {
+  // Add place holders
+  _map["-h"] = nullptr;
+  _map["--help"] = nullptr;
+}
+
+
+
+
+
+
+}
+}

--- a/src/server/common/CmdArg.h
+++ b/src/server/common/CmdArg.h
@@ -1,0 +1,179 @@
+/*
+ * CmdArg.h
+ *
+ *  Created on: 20 Oct 2016
+ *      Author: jonas
+ */
+
+#ifndef SERVER_COMMON_CMDARG_H_
+#define SERVER_COMMON_CMDARG_H_
+
+#include <server/common/Array.h>
+#include <string>
+#include <map>
+#include <server/common/Unmovable.h>
+
+namespace sail {
+namespace CmdArg {
+
+// Result of applying the handler to this input form
+class Result {
+public:
+  Result(bool success, const std::string &e = "Unspecified") :
+    _success(success), _error(e) {};
+  static Result success() {return Result(true);}
+  static Result failure(const std::string &e) {
+    return Result(false, e);
+  }
+
+  bool succeeded() const {return _success;}
+  bool failed() const {return !_success;}
+  operator bool() {return _success;}
+  std::string toString() const {return _error;}
+private:
+  bool _success;
+  std::string _error;
+};
+
+struct ArgSpec {
+  std::string name, type, desc;
+};
+
+class InputForm {
+public:
+  InputForm() {}
+
+  typedef std::function<Result(Array<std::string>)> Handler;
+  InputForm(
+      const Array<ArgSpec> &specs,
+      const Handler &handler) :
+        _argSpecs(specs),
+        _handler(handler) {}
+  Result parse(const Array<std::string> &remainingArgs) const;
+  InputForm &describe(const std::string &d);
+  int argCount () const {return _argSpecs.size();}
+  void outputHelp(int depth, std::ostream *dst) const;
+private:
+  Array<ArgSpec> _argSpecs;
+  Handler _handler;
+  std::string _desc;
+};
+
+
+template <typename T>
+class Arg {
+public:
+  typedef Arg<T> ThisType;
+  typedef T type;
+
+  Arg(const std::string &name) : _name(name) {}
+  ThisType &describe(const std::string &d);
+
+  T parseAndProceed(std::string **s) const;
+
+  std::string description() const;
+  ArgSpec spec() const;
+  Arg<T> &dontRejectFlags();
+private:
+
+  // By default, we reject arguments that
+  // look like flags.
+  bool _acceptFlags = false;
+
+  std::string _name, _desc;
+};
+
+
+// Rename to InputFormGroup
+class Entry {
+public:
+  static const int DefaultMaxCount =
+      std::numeric_limits<int>::max();
+
+  Entry(
+      const Array<std::string> &commands,
+      const Array<InputForm> &forms);
+  Entry &describe(const std::string &d);
+
+  bool parse(
+      std::vector<Result> *failureReasons,
+      Array<std::string> *remaingArgsInOut);
+
+  const Array<std::string> &commands() const;
+
+  typedef std::shared_ptr<Entry> Ptr;
+
+  void outputHelp(int depth, std::ostream *dst) const;
+
+  Entry &required();
+  Entry &setMinCount(int n);
+  Entry &setMaxCount(int n);
+  std::string callSpec() const;
+  Result checkCallCount() const;
+private:
+  int _callCount = 0;
+  int _minCount = 0;
+  int _maxCount = DefaultMaxCount;
+  std::string _description;
+  Array<std::string> _commands;
+  Array<InputForm> _forms;
+};
+
+class Parser {
+public:
+  Parser(const std::string &desc);
+
+  enum Status {
+    Done,
+    Continue,
+    Error
+  };
+
+  Entry &bind(
+      const Array<std::string> &commands,
+      const Array<InputForm> &inputForms);
+
+  Status parse(int argc, const char **argv);
+  const std::vector<std::string> &freeArgs() const {
+    return _freeArgs;
+  }
+private:
+  MAKE_UNMOVABLE(Parser);
+  std::vector<std::string> _freeArgs;
+  bool _initialized, _helpDisplayed;
+  std::string _description;
+  std::vector<Entry::Ptr> _entries;
+  std::map<std::string, Entry::Ptr> _map;
+
+  Entry::Ptr addEntry(const Entry::Ptr &e);
+  Entry &addAndRegisterEntry(const Entry::Ptr &e);
+  void displayHelpMessage();
+  void initialize();
+};
+
+
+template <typename Function, typename... Arg>
+InputForm inputForm(
+    Function f, Arg ... arg) {
+  auto specs = Array<ArgSpec>{arg.spec()...};
+  return InputForm(
+      specs,
+      [=](const Array<std::string> &args) -> Result {
+    if (args.size() < sizeof...(Arg)) {
+      return Result::failure("Too few arguments provided");
+    }
+    std::string *s0 = args.ptr();
+    auto s = &s0;
+    try {
+      return Result(f(arg.parseAndProceed(s)...));
+    } catch (const std::exception &e) {
+      return Result::failure(e.what());
+    }
+  });
+}
+
+}
+}
+
+
+#endif /* SERVER_COMMON_CMDARG_H_ */

--- a/src/server/common/CmdArgTest.cpp
+++ b/src/server/common/CmdArgTest.cpp
@@ -1,0 +1,380 @@
+/*
+ * CmdArgTest.cpp
+ *
+ *  Created on: 20 Oct 2016
+ *      Author: jonas
+ */
+
+#include <gtest/gtest.h>
+#include <server/common/CmdArg.h>
+#include <server/common/logging.h>
+
+using namespace sail;
+using namespace sail::CmdArg;
+
+struct TestSetup {
+  double a = 0.0;
+  double b = 0.0;
+  double value = 0.0;
+  std::string unit;
+};
+
+TEST(CmdArgTest, Tutorial) {
+  TestSetup setup;
+
+
+  // Here we configure the parser.
+  Parser cmd("CompleteExample: This is the message shown at the top");
+
+  // 'bind' is used to add an option.
+  cmd.bind({"--wave", "-w"}, {
+
+      // Just like functions in C++ can be overloaded for
+      // different arguments, so can InputForm's here. Here we
+      // have two such InputForm's. The forms are visited
+      // in the order listed, and the first form that is
+      // compatible with the input arguments will be the one used.
+
+      // The inputForm variadic template function takes
+      // as first argument a functor, followed by a variadic
+      // number of Arg<...> objects that specify the arguments
+      // that the functor accepts.
+
+      /*1st form*/ inputForm([&](double amp, double phase) {
+        setup.a = amp;
+        setup.b = phase;
+
+        // We must return something from which a Result
+        // object can be constructed. Returning true
+        // means success.
+        return true;
+      }, Arg<double>("amp"),   // Relates to 'double amp' in the functor above
+         Arg<double>("phase")  // Relates to 'double phase' in the functor above
+        .describe("in radians")) // (1/3) Individual arguments can be described
+       .describe("Specify a wave by amp and phase"), // (2/3) Input forms can be described
+
+       // This form has fewer argument than the first form.
+       // That means that, whatever input the first form accepts,
+       // so does this form. Therefore, it must follow the first
+       // form because otherwise that form would never be called.
+       /*2nd form*/inputForm([&](double amp) {
+         setup.a = amp;
+         setup.b = 0.0;
+         return true;
+       }, Arg<double>("amp"))
+       .describe("Specify a wave with default phase 0")
+
+  }).describe("Specify a wave"); // (3/3) Options can be described
+  // As you may see, there are three different things that can
+  // be described: Invidivual arguments, input forms, and
+  // entire options. The provided descriptions are used
+  // to generate documentation.
+
+  cmd.bind({"--sampling"}, {
+
+      inputForm([&](double v, std::string u) {
+        if (u != "hz" && u != "s") {
+          // We can return a failure from inside a functor.
+          // This will show up as a message in the output
+          // and parsing will be interupted if no other form
+          // was able to handle the input.
+          return Result::failure("Illegal sampling unit: " + u);
+        }
+        setup.value = v;
+        setup.unit = u;
+        return Result::success();
+
+      }, Arg<double>("value"),
+         Arg<std::string>("unit")
+           .describe("Frequency in hz or period time in s"))
+      .describe("A value and a unit")
+
+  }).describe("Specify the sampling");
+
+  // Make some fake input.
+  const int argc = 7;
+  const char *argv[argc] = {
+      "prg-name", "--wave", "9", "7",
+      "--sampling", "6", "hz"};
+
+  // Here we run the parser
+  EXPECT_EQ(Parser::Continue, cmd.parse(argc, argv));
+
+  // Parser::Continue means that the parser didn't encounter
+  // any problems, and we can move on.
+  EXPECT_EQ(setup.a, 9.0);
+  EXPECT_EQ(setup.b, 7.0);
+  EXPECT_EQ(setup.value, 6.0);
+  EXPECT_EQ(setup.unit, "hz");
+  EXPECT_EQ(0, cmd.freeArgs().size());
+}
+
+
+
+
+
+
+TEST(CmdArgTest, InputFormTest) {
+  double a = 0.0;
+  double b = 0.0;
+
+  auto form = inputForm(
+      [&](double amp, double phase) {
+    a = amp;
+    b = phase;
+    return true;
+  },
+  Arg<double>("amp").describe("The amplitude, in meters"),
+  Arg<double>("phase").describe("The phase, in radians"));
+
+  EXPECT_TRUE(bool(form.parse({"3", "4"})));
+  EXPECT_NEAR(a, 3.0, 1.0e-5);
+  EXPECT_NEAR(b, 4.0, 1.0e-5);
+
+  EXPECT_FALSE(bool(form.parse({"a", "b"})));
+  EXPECT_NEAR(a, 3.0, 1.0e-5);
+  EXPECT_NEAR(b, 4.0, 1.0e-5);
+}
+
+TEST(CmdArgTest, EntryTest) {
+  double a = 0.0;
+  double b = 0.0;
+  double c = 0.0;
+  std::string d = "";
+
+  Entry e({"--wave", "-w"}, {
+
+    // Put the form with more arguments before the
+    // version with fewer, if there is ambiguity.
+    inputForm([&](double amp, double phase) {
+      b = amp;
+      c = phase;
+
+      // ALWAYS return something here from which
+      // an CmdArgResult object can be constructed.
+      return true;
+
+    }, // Specify the meaning of each argument:
+        Arg<double>("amplitude"),
+        Arg<double>("phase").describe("in radians"))
+        // ...and the meaning of the entire form
+          .describe(
+           "Wave with specified amplitude and phase"),
+
+     inputForm([&](double amp) {
+       a = amp;
+       return true;
+     }, Arg<double>("amplitude"))
+       .describe("Wave with specified amplitude and 0 phase"),
+
+    inputForm([&](std::string f) {
+      d = f;
+      return true;
+    }, Arg<std::string>("whatever").describe("Put any expr here"))
+      .describe("Freeform wave spec")
+  });
+
+  {
+    std::vector<Result> reasons;
+    Array<std::string> args{"kattskit"};
+    EXPECT_TRUE(e.parse(&reasons, &args));
+    EXPECT_EQ(d, "kattskit");
+    EXPECT_EQ(reasons.size(), 2);
+  }{
+    std::vector<Result> reasons;
+    Array<std::string> args;
+    EXPECT_FALSE(e.parse(&reasons, &args));
+    EXPECT_EQ(reasons.size(), 3);
+  }{
+    std::vector<Result> reasons;
+    Array<std::string> args{"9"};
+    EXPECT_TRUE(e.parse(&reasons, &args));
+    EXPECT_EQ(reasons.size(), 1);
+    EXPECT_NEAR(a, 9.0, 1.0e-6);
+  }
+}
+
+
+
+
+void withTestSetup(std::function<void(TestSetup*,Parser*)> handler) {
+  TestSetup setup;
+
+  Parser cmd("This is the message shown at the top");
+
+  cmd.bind({"--wave", "-w"}, {
+
+      inputForm([&](double amp, double phase) {
+        setup.a = amp;
+        setup.b = phase;
+        return true;
+      }, Arg<double>("amp"), Arg<double>("phase")
+        .describe("in radians"))
+       .describe("Specify a wave by amp and phase"),
+
+
+      inputForm([&](double amp) {
+        setup.a = amp;
+        setup.b = 0.0;
+        return true;
+      }, Arg<double>("amp"))
+      .describe("Specify a wave with default phase 0")
+
+  }).describe("Specify a wave");
+
+  cmd.bind({"--sampling"}, {
+
+      inputForm([&](double v, std::string u) {
+        if (u != "hz" && u != "s") {
+          return Result::failure("Illegal sampling unit: " + u);
+        }
+        setup.value = v;
+        setup.unit = u;
+        return Result::success();
+
+      }, Arg<double>("value"),
+         Arg<std::string>("unit")
+           .describe("Frequency in hz or period time in s"))
+      .describe("A value and a unit")
+
+  }).describe("Specify the sampling");
+
+  handler(&setup, &cmd);
+}
+
+
+TEST(CmdArgTest, BasicTesting) {
+  {
+    bool called = false;
+    withTestSetup([&](TestSetup *s, Parser *cmd) {
+
+      const int argc = 7;
+      const char *argv[argc] = {
+          "prg-name", "--wave", "9", "7",
+          "--sampling", "6", "hz"};
+
+      EXPECT_EQ(Parser::Continue, cmd->parse(argc, argv));
+
+      EXPECT_EQ(s->a, 9.0);
+      EXPECT_EQ(s->b, 7.0);
+      EXPECT_EQ(s->value, 6.0);
+      EXPECT_EQ(s->unit, "hz");
+      EXPECT_EQ(0, cmd->freeArgs().size());
+
+      called = true;
+    });
+    EXPECT_TRUE(called);
+  }{
+    bool called = false;
+    withTestSetup([&](TestSetup *s, Parser *cmd) {
+
+      const int argc = 7;
+      const char *argv[argc] = {
+          "prg-name", "--wave", "9", "7",
+          "--sampling", "6", "asdfasdfasdf"};
+
+      EXPECT_EQ(Parser::Error, cmd->parse(argc, argv));
+      called = true;
+    });
+    EXPECT_TRUE(called);
+  }{
+    bool called = false;
+    withTestSetup([&](TestSetup *s, Parser *cmd) {
+
+      const int argc = 8;
+      const char *argv[argc] = {
+          "prg-name", "--wave", "9", "7", "this-arg-is-free",
+          "--sampling", "6", "hz"};
+      EXPECT_EQ(Parser::Continue, cmd->parse(argc, argv));
+      EXPECT_EQ(1, cmd->freeArgs().size());
+      EXPECT_EQ("this-arg-is-free", cmd->freeArgs()[0]);
+      called = true;
+    });
+    EXPECT_TRUE(called);
+  }{
+    bool called = false;
+    withTestSetup([&](TestSetup *s, Parser *cmd) {
+
+      const int argc = 2;
+      const char *argv[argc] = {
+          "prg-name", "--help"
+      };
+      EXPECT_EQ(Parser::Done, cmd->parse(argc, argv));
+      EXPECT_EQ(0, cmd->freeArgs().size());
+      called = true;
+    });
+    EXPECT_TRUE(called);
+  }
+}
+
+TEST(CmdArgTest, AcceptFlagsTest) {
+
+  using namespace CmdArg;
+  {
+    Parser parser("Test");
+    parser.bind({"--name"}, {
+
+      inputForm([&](const std::string &s) {
+        return true;
+      }, Arg<std::string>("name"))
+
+    }).describe("The name");
+
+    const int n = 3;
+    const char *args[n] = {"prg-name", "--name", "--rulle"};
+    EXPECT_EQ(Parser::Error, parser.parse(n, args));
+  }{
+    Parser parser("Test");
+    parser.bind({"--name"}, {
+
+      inputForm([&](const std::string &s) {
+        return true;
+      }, Arg<std::string>("name")
+        .dontRejectFlags()) // <-- Will not complain about '--rulle'
+
+    }).describe("The name");
+
+    const int n = 3;
+    const char *args[n] = {"prg-name", "--name", "--rulle"};
+    EXPECT_EQ(Parser::Continue, parser.parse(n, args));
+  }
+}
+
+TEST(CmdArgTest, Required) {
+  using namespace CmdArg;
+
+  {
+    Parser parser("test");
+    bool gotIt = false;
+    parser.bind({"--age", "-a"}, {
+      inputForm([&]() {
+        gotIt = true;
+        return true;
+      })
+    }).required();
+    const int n = 1;
+    const char *args[n] = {"prg-name"};
+    EXPECT_EQ(Parser::Error, parser.parse(n, args));
+    EXPECT_FALSE(gotIt);
+  }
+}
+
+TEST(CmdArgTest, MaxCount) {
+  using namespace CmdArg;
+
+  {
+    Parser parser("test");
+    bool gotIt = false;
+    parser.bind({"--age", "-a"}, {
+      inputForm([&]() {
+        gotIt = true;
+        return true;
+      })
+    }).setMaxCount(1);
+    const int n = 4;
+    const char *args[n] = {"prg-name", "--age", "-a", "-a"};
+    EXPECT_EQ(Parser::Error, parser.parse(n, args));
+    EXPECT_TRUE(gotIt);
+  }
+}
+


### PR DESCRIPTION
I found the current command line parser `ArgMap` very impractical to use to the extent that I decided to write a new one. _See the test case_ named `Tutorial` for an example of how to use it. I hope that we over time can migrate to this new command-line parser. The new parser 
- Can in a typesafe way map the raw input arguments to C++ types, such as `std::string`, `int`, `bool`, etc.
- Can support overloading of options, so that we can accept options on different forms.
- Has much richer help and error messages.

Ideally I would want remove the old command line parser to avoid having two different implementations that do the same thing, but currently we have a lot of code depending on the old parser that I am not going to do that in this PR.
