### PR TITLE
Improve server response time on full maps

### DIFF
--- a/www2/server/api/tiles/tiles.controller.js
+++ b/www2/server/api/tiles/tiles.controller.js
@@ -27,7 +27,10 @@ function fetchTiles(boatId, scale, x, y, startsAfter, endsBefore, callback) {
                         y,
                         startsAfter,
                         endsBefore);
-  Tiles.find(query, function(err, tiles) {
+  // This query might return many tiles. The lean() call tells mongoose to
+  // pass raw objects instead of trying to apply magic to them. There is a
+  // significant speed difference!
+  Tiles.find(query).lean().exec(function(err, tiles) {
     if (err) {
       return callback(err, null);
     }


### PR DESCRIPTION
When getting the full map for a boat, many tiles are returned.
Previously, mongoose processed the results with expansive (and useless) magic.
This change switches to mongoose lean mode, improving drastically the server
response time for full maps.