### PR TITLE
Speedup tiles generation

### DIFF
--- a/src/server/nautical/tiles/NavTileGenerator.h
+++ b/src/server/nautical/tiles/NavTileGenerator.h
@@ -46,11 +46,14 @@ double posToTileY(int scale, const GeographicPosition<double>& pos);
 
 Array<Array<Nav>> generateTiles(TileKey tileKey,
                                 const Array<Nav>& navs,
+                                const std::vector<int>& navIndices,
                                 int maxNumNavs,
                                 Duration<> curveCutThreshold);
 
-// Return a set of tiles on which "navs" should appear.
-std::set<TileKey> tilesForNav(const Array<Nav>& navs, int maxScale);
+// Return a map of tiles on which "navs" should appear, with the list of
+// corresponding navs index.
+std::map<TileKey, std::vector<int>> tilesForNav(
+    const Array<Nav>& navs, int maxScale);
 
 // Generate a unique identifier for this Nav curve.
 std::string tileCurveId(std::string boatId, const NavDataset& navs);

--- a/src/server/nautical/tiles/NavTileGeneratorTest.cpp
+++ b/src/server/nautical/tiles/NavTileGeneratorTest.cpp
@@ -9,6 +9,7 @@
 namespace sail {
 
 using namespace NavCompat;
+using namespace std;
 
 TEST(NavTileGenerator, SmokeTest) {
   Array<Nav> navs(100);
@@ -26,9 +27,12 @@ TEST(NavTileGenerator, SmokeTest) {
   }
 
   TileKey tile(1, 1, 0);
+  map<TileKey, vector<int>> tileIndex = tilesForNav(navs, 2);
   Array<Array<Nav>> result = generateTiles(
       tile, // A quarter of the world
-      navs, 5, 1.0_minutes);
+      navs,
+      tileIndex[tile],
+      5, 1.0_minutes);
 
   EXPECT_EQ(1, result.size());
   EXPECT_EQ(5, result[0].size());
@@ -38,10 +42,12 @@ TEST(NavTileGenerator, SmokeTest) {
     EXPECT_TRUE(tile.contains(nav.geographicPosition()));
   }
 
-  for (const Nav& nav : navs) {
+  for (int i = 0; i < navs.size(); ++i) {
+    const Nav& nav = navs[i];
     if (nav.time() < result[0].first().time()
         || nav.time() > result[0].last().time()) {
-      EXPECT_FALSE(tile.contains(nav.geographicPosition()));
+      EXPECT_FALSE(tile.contains(nav.geographicPosition()))
+        << "at nav[" << i << "]";
     }
   }
 }
@@ -66,9 +72,12 @@ TEST(NavTileGenerator, SplitTest) {
   }
 
   TileKey tile(1, 1, 0);
+  map<TileKey, vector<int>> tileIndex = tilesForNav(navs, 2);
   Array<Array<Nav>> result = generateTiles(
       tile, // A quarter of the world
-      navs, 5, 1.0_minutes);
+      navs,
+      tileIndex[tile],
+      5, 1.0_minutes);
 
   EXPECT_EQ(2, result.size());
   EXPECT_EQ(5, result[0].size());

--- a/src/server/nautical/tiles/NavTileUploader.cpp
+++ b/src/server/nautical/tiles/NavTileUploader.cpp
@@ -22,6 +22,8 @@ namespace mongo { namespace client { void initialize() { } } }
 namespace sail {
 
 using namespace NavCompat;
+using std::vector;
+using std::map;
 
 namespace {
 BSONObj navToBSON(const Nav& nav) {
@@ -344,12 +346,15 @@ bool generateAndUploadTiles(std::string boatId,
 
     std::string curveId = tileCurveId(boatId, curve);
 
-    std::set<TileKey> tiles = tilesForNav(navs, params.maxScale);
+    map<TileKey, vector<int>> tiles = tilesForNav(navs, params.maxScale);
 
-
-    for (auto tileKey : tiles) {
+    for (auto it : tiles) {
+      const TileKey& tileKey = it.first;
       Array<Array<Nav>> subCurvesInTile = generateTiles(
-          tileKey, navs, params.maxNumNavsPerSubCurve, params.curveCutThreshold);
+          tileKey,
+          navs,
+          it.second, // the vector of nav indices
+          params.maxNumNavsPerSubCurve, params.curveCutThreshold);
 
       if (subCurvesInTile.size() == 0) {
         continue;


### PR DESCRIPTION
Instead of iterating over all nav to check if it belongs to a tile,
index navs in a map with the tile key.

Generating the full map for Zed4 takes about 15 minutes on my laptop.
(together with the jp-bulk changes) (as opposed to 33 hours on the production servers).