### PR TITLE
Fix time window of perf chart on full map

### DIFF
--- a/www2/client/app/perfplot/perfplot.directive.js
+++ b/www2/client/app/perfplot/perfplot.directive.js
@@ -166,10 +166,12 @@ angular.module('www2App')
           var d =graph.x.domain();
           var newDomain =
             [new Date(source.first), new Date(source.last)];
-          if ($scope.startTime.getTime() > 10000) {
+          if ($scope.startTime instanceof Date
+              && $scope.startTime.getTime() > 10000) {
             newDomain[0] = new Date($scope.startTime);
           }
-          if ($scope.endTime.getTime() > 10000) {
+          if ($scope.endTime instanceof Date
+              && $scope.endTime.getTime() > 10000) {
             newDomain[1] = new Date($scope.endTime);
           }
 


### PR DESCRIPTION
When $scope.startTime is undefined, an exception prevented correct
execution of graph.setTimeBounds.