### PR TITLE
Fix chart issues on mobile

### DIFF
--- a/www2/client/app/perfplot/perfplot.css
+++ b/www2/client/app/perfplot/perfplot.css
@@ -1,3 +1,23 @@
+.graph-container {
+  /* see the following page for an explanation
+   * https://developers.google.com/web/updates/2017/01/scrolling-intervention
+   *
+   * Basically, we have to tell chrome we'll handle touch events ourselves.
+   * The preventDefault() way that works with other browsers is not working
+   * with chrome. "aggressive optimization" ?
+   */
+  touch-action: none;
+}
+
+.graph-controls {
+  position: absolute;
+  top: 0px;
+}
+
+.graph-controls select {
+  max-width: 40%;
+}
+
 svg {
   font-size: 10px;
 }

--- a/www2/client/app/perfplot/perfplot.directive.js
+++ b/www2/client/app/perfplot/perfplot.directive.js
@@ -179,10 +179,16 @@ angular.module('www2App')
           graph.draw();
         };
 
+        var zoomRefreshTimeout;
         graph.onZoom = function() {
-          var d =graph.x.domain();
-          $scope.startTime = new Date(d[0]);
-          $scope.endTime = new Date(d[1]);
+          if (zoomRefreshTimeout) {
+            $timeout.cancel(zoomRefreshTimeout);
+          }
+          zoomRefreshTimeout = $timeout(function() {
+            var d =graph.x.domain();
+            $scope.startTime = new Date(d[0]);
+            $scope.endTime = new Date(d[1]);
+          }, 100);
         };
 
         var selectionChanged = function() {

--- a/www2/client/app/perfplot/perfplot.html
+++ b/www2/client/app/perfplot/perfplot.html
@@ -1,6 +1,6 @@
 <div style="height:100%; position:relative;">
   <div style="height:100%;" class="graph-container"></div>
-  <div style="position:absolute; top:0px;">
+  <div class="graph-controls">
     <select id="channelSelect"
               ng-model="channel"
               ng-options="c for c in channelList track by c"></select>

--- a/www2/client/app/perfplot/perfplot.js
+++ b/www2/client/app/perfplot/perfplot.js
@@ -237,7 +237,6 @@ Graph.prototype.setTimeBounds = function(startTime, endTime) {
 
 Graph.prototype.setYBounds = function(data) {
   if (data.length > 1) {
-    var me = this;
     var getField = function(d) { return d.value; };
     this.y.domain([
       Math.min(0, d3.min(data, getField)),
@@ -266,10 +265,12 @@ Graph.prototype.draw = function() {
   var svg = this.svg;
   svg.select("g.x.axis").call(this.xAxis);
   svg.select("g.y.axis").call(this.yAxis);
-  svg.select("path.area").attr("d", this.area);
-  svg.select("#lowLine").attr("d", this.lowLine);
-  svg.select("#highLine").attr("d", this.highLine);
-  svg.select("#mainLine").attr("d", this.line);
+  if (this.hasData) {
+    svg.select("path.area").attr("d", this.area);
+    svg.select("#lowLine").attr("d", this.lowLine);
+    svg.select("#highLine").attr("d", this.highLine);
+    svg.select("#mainLine").attr("d", this.line);
+  }
 
   var x = this.x;
   var selection = this.svg.select("g.timeMarks").selectAll("rect").data(this.times);
@@ -313,16 +314,17 @@ Graph.prototype.prepareTileData = function() {
       }
     });
 
-    if (data.length == 0 && dataPending) {
-      return false;
+
+    if (data.length > 0) {
+      this.hasData = true;
+      this.setYBounds(data);
+      this.svg.select("path.area").data([data]);
+      this.svg.select("#mainLine").data([data]);
+      this.svg.select("#lowLine").data([data]);
+      this.svg.select("#highLine").data([data]);
+    } else {
+      this.hasData = false;
     }
-
-    this.setYBounds(data);
-
-    this.svg.select("path.area").data([data]);
-    this.svg.select("#mainLine").data([data]);
-    this.svg.select("#lowLine").data([data]);
-    this.svg.select("#highLine").data([data]);
 
     return true;
   }


### PR DESCRIPTION
when scrolling and zooming on the perf chart, several issues
occured on mobile:
- a chrome optimization made it complain in the console and
  "jump" randomly
- long source names could take too much space and hide data
- bad interaction between onZoom callback and angular was also
  causing jumps