### PR TITLE
Destructive replay

### DIFF
--- a/src/device/anemobox/DispatcherUtils.h
+++ b/src/device/anemobox/DispatcherUtils.h
@@ -161,6 +161,11 @@ void exportDispatcherToTextFiles(const std::string &filenamePrefix,
 class ReplayDispatcher : public Dispatcher {
  public:
 
+  struct Settings {
+    Settings() {}
+    bool destructive = false;
+  };
+
   struct Timeout {
     int64_t id;
     TimeStamp time;
@@ -171,7 +176,7 @@ class ReplayDispatcher : public Dispatcher {
     }
   };
 
-  ReplayDispatcher();
+  ReplayDispatcher(const Settings& s = Settings());
 
    TimeStamp currentTime() override {
      return _currentTime;
@@ -205,6 +210,7 @@ class ReplayDispatcher : public Dispatcher {
      return _timeouts;
    }
  private:
+   Settings _settings;
    void visitTimeouts();
    int64_t _counter;
    std::set<Timeout> _timeouts;

--- a/src/device/anemobox/TimedSampleCollection.h
+++ b/src/device/anemobox/TimedSampleCollection.h
@@ -38,6 +38,7 @@ class TimedSampleCollection : public SampledSignal<T> {
    void append(TimeStamp t, T value) { append(TimedValue<T>(t, value)); }
 
    const TimedVector& samples() const { return _samples; }
+   TimedVector* mutableSamples() {return &_samples;}
 
    const TimedValue<T>& back(int backIndex) const {
      assert(backIndex >= 0 && size_t(backIndex) < _samples.size());

--- a/src/device/anemobox/ValueDispatcher.h
+++ b/src/device/anemobox/ValueDispatcher.h
@@ -74,6 +74,7 @@ class ValueDispatcher {
   virtual TimeStamp lastTimeStamp() const { return values_.lastTimeStamp(); }
 
   virtual const TimedSampleCollection<T>& values() const { return values_; }
+  virtual TimedSampleCollection<T>* mutableValues() { return &values_; }
 
   void insert(const typename TimedSampleCollection<T>::TimedVector& values) {
     values_.insert(values);

--- a/src/device/anemobox/simulator/SimulateBox.h
+++ b/src/device/anemobox/simulator/SimulateBox.h
@@ -9,8 +9,12 @@
 
 namespace sail {
 
+NavDataset SimulateBox(
+    std::istream &boatDat,
+    const NavDataset &ds);
 NavDataset SimulateBox(const std::string& boatDat, const NavDataset &ds);
-NavDataset SimulateBox(std::istream& boatDat, const NavDataset &ds);
+bool SimulateBox(const std::string& boatDat, NavDataset *ds);
+
 
 }  // namespace sail
 

--- a/src/server/nautical/BoatLogProcessor.cpp
+++ b/src/server/nautical/BoatLogProcessor.cpp
@@ -410,9 +410,9 @@ bool BoatLogProcessor::process(ArgMap* amap) {
   // write calibration and target speed to disk
   boatDatFile.close();
 
-  // Second simulation path to apply target speed.
+  // Second simulation pass to apply target speed.
   // Todo: simply lookup the target speed instead of recomputing true wind.
-  current = SimulateBox(boatDatPath, current);
+  SimulateBox(boatDatPath, &current);
 
   if (_debug) {
     visualizeBoatDat(_dstPath);

--- a/src/server/nautical/calib/Calibrator.cpp
+++ b/src/server/nautical/calib/Calibrator.cpp
@@ -502,11 +502,10 @@ void Calibrator::clear() {
   _maneuvers.clear();
 }
 
-NavDataset Calibrator::simulate(const NavDataset &src) const {
+NavDataset Calibrator::simulate(const NavDataset& src) const {
   std::stringstream calibFile;
   saveCalibration(&calibFile);
   calibFile.seekg(0, std::ios::beg);
-
   return SimulateBox(calibFile, src);
 }
 

--- a/src/server/nautical/calib/Calibrator.h
+++ b/src/server/nautical/calib/Calibrator.h
@@ -49,7 +49,7 @@ class Calibrator  {
     void setVerbose() { _verbose = true; }
 
     //! Use the calibration to compute true wind on the given navigation data.
-    NavDataset simulate(const NavDataset &array) const;
+    NavDataset simulate(const NavDataset& src) const;
 
     //! Returns the number of maneuvers used to fit the data.
     int maneuverCount() const {


### PR DESCRIPTION
These changes reduce maximum memory consumption from 3.6 GB to 2.2 GB for Courdileone, at the expense of more complex code.