### PR TITLE
Add a sequential outlier filter and segmenter

### DIFF
--- a/src/server/math/CMakeLists.txt
+++ b/src/server/math/CMakeLists.txt
@@ -136,6 +136,19 @@ cxx_test(math_Curve2dFilterTest
   gtest_main
   )
 
+add_library(math_SeqOutlierFilter
+  SeqOutlierFilter.h
+  SeqOutlierFilter.cpp
+  )
+
+cxx_test(math_SeqOutlierFilterTest
+  SeqOutlierFilterTest.cpp
+  gtest_main
+  common_logging
+  math_SeqOutlierFilter
+  )
+  
+
 add_subdirectory(spline)
 add_subdirectory(geometry)
 add_subdirectory(hmm)

--- a/src/server/math/SeqOutlierFilter.cpp
+++ b/src/server/math/SeqOutlierFilter.cpp
@@ -1,0 +1,162 @@
+/*
+ * SeqOutlierFilter.cpp
+ *
+ *  Created on: 15 Jun 2017
+ *      Author: jonas
+ */
+#include <server/math/SeqOutlierFilter.h>
+#include <map>
+
+namespace sail {
+namespace SeqOutlierFilter {
+
+
+void IndexGrouper::flush() {
+  if(_counter - _lastFrom > 0) {
+    IndexSpan x;
+    x.index = _lastIndex;
+    x.span = Span<int>(_lastFrom, _counter);
+    _groups.add(x);
+  }
+}
+
+void IndexGrouper::insert(int index) {
+  if (index != _lastIndex) {
+    flush();
+    _lastFrom = _counter;
+  }
+  _lastIndex = index;
+  _counter++;
+}
+
+Array<IndexSpan> IndexGrouper::get() {
+  flush();
+  return _groups.get();
+}
+
+struct SegmentInfo;
+
+int bestSegment(int a, int b, const Array<SegmentInfo>& data);
+
+struct SegmentInfo {
+  int arrayIndex = -1;
+  Span<int> totalExtent;
+  int totalSamples = 0;
+  int segmentIndex = -1;
+  int bestPredecessor = -1;
+  int cumulativeSampleCount = 0;
+  std::vector<int> predecessors;
+
+  void computeBestPredecessor(const Array<SegmentInfo>& data) {
+    for (auto i: predecessors) {
+      bestPredecessor = bestSegment(bestPredecessor, i, data);
+    }
+    cumulativeSampleCount = totalSamples +
+        (bestPredecessor == -1? 0
+            : data[bestPredecessor].cumulativeSampleCount);
+  }
+};
+
+int bestSegment(int a, int b, const Array<SegmentInfo>& data) {
+  if (a == -1) {
+    return b;
+  } else if (b == -1) {
+    return a;
+  }
+  return data[a].cumulativeSampleCount < data[b].cumulativeSampleCount?
+      b : a;
+}
+
+
+Array<SegmentInfo> computeTotalSpans(
+    const Array<IndexSpan>& spans) {
+  std::map<int, SegmentInfo> dst;
+  int counter = 0;
+  for (auto span: spans) {
+    auto& x = dst[span.index];
+    x.segmentIndex = span.index;
+    x.totalExtent.extend(span.span);
+    x.totalSamples += span.span.width();
+    x.arrayIndex = x.arrayIndex == -1? counter++ : x.arrayIndex;
+  }
+  Array<SegmentInfo> flat(counter);
+  for (auto kv: dst) {
+    flat[kv.second.arrayIndex] = kv.second;
+  }
+  return flat;
+}
+
+void connect(SegmentInfo* x, SegmentInfo* y) {
+  y->predecessors.push_back(x->arrayIndex);
+}
+
+void connectToSuccessors(Array<SegmentInfo>* data, int index) {
+  auto& x = (*data)[index];
+  int minExtent = std::numeric_limits<int>::max();
+  for (int i = index+1; i < data->size(); i++) {
+    auto& y = (*data)[i];
+
+    // In case the condition below holds, any further
+    // connections would never be needed, because it
+    // would always be more optimal to include the segment that
+    // resulted in the current value of 'minExtent' and connect
+    // that segment to 'y', than omitting the segment corresponding to
+    // 'minExtent'.
+    if (minExtent <= y.totalExtent.minv()) {
+      break;
+    }
+    // Test if non-overlapping.
+    if (x.totalExtent.maxv() <= y.totalExtent.minv()) {
+      connect(&x, &y);
+      minExtent = std::min(minExtent, y.totalExtent.maxv());
+    }
+  }
+}
+
+void buildGraph(Array<SegmentInfo>* data) {
+  for (int i = 0; i < data->size(); i++) {
+    connectToSuccessors(data, i);
+  }
+}
+
+std::set<int> getInlierSegmentSet(
+    const Array<SegmentInfo>& data, int final) {
+  std::set<int> dst;
+  for (int i = final; i != -1; i = data[i].bestPredecessor) {
+    dst.insert(data[i].segmentIndex);
+  }
+  return dst;
+}
+
+std::set<int> computeInlierSegments(
+    const Array<IndexSpan>& spans) {
+
+  // Because we can have multiple contiguous
+  // spans with the same segment index, we group them here
+  // into an array of SegmentInfo. The array index is
+  // *does not* correspond to the segment index, but is
+  // used as a reference in the dynamic programming problem that
+  // we will solve.
+  auto total = computeTotalSpans(spans);
+
+  // Here we connect every segment with its closest successors
+  // that are not overlapping with it.
+  buildGraph(&total);
+
+  // Here we do a forward sweep in the dynamic programming problem.
+  // The objective is to choose a subset of the SegmentInfo elements
+  // such that the total number of samples is maximized, subject to
+  // the constraint that 'totalSpan' of two SegmentInfo cannot overlap.
+  // That constraint is encoded in the graph that we built previously.
+  int best = -1;
+  for (auto& x: total) {
+    x.computeBestPredecessor(total);
+    best = bestSegment(best, x.arrayIndex, total);
+  }
+
+  // Here we unwind the solution starting from the best final segment.
+  return getInlierSegmentSet(total, best);
+}
+
+}
+}

--- a/src/server/math/SeqOutlierFilter.h
+++ b/src/server/math/SeqOutlierFilter.h
@@ -1,0 +1,226 @@
+/*
+ * SeqOutlierFilter.h
+ *
+ *  Created on: 9 Jun 2017
+ *      Author: jonas
+ */
+
+#ifndef SERVER_MATH_SEQOUTLIERFILTER_H_
+#define SERVER_MATH_SEQOUTLIERFILTER_H_
+
+#include <server/common/indexed.h>
+#include <server/common/logging.h>
+#include <server/common/Span.h>
+#include <set>
+
+namespace sail {
+namespace SeqOutlierFilter {
+
+struct Settings {
+  // This is maximum number of local models that we keep track
+  // of. A higher number here is likely to lead to better segmentations
+  // in difficult cases, but the time complexity is also linear w.r.t.
+  // this parameter.
+  int maxLocalModelCount = 0;
+
+  // This parameter is used as a threshold to distinguish between
+  // what is noise or natural model inaccuracies
+  // (e.g. fitting a parabola to a circular arc),
+  // versus what is outlier data.
+  double maxLocalModelCost = 0;
+};
+
+
+// This State template class corresponds to a
+// the state of a causal filter. Its most important
+// method is 'filter', that updates the filter with
+// an observation, and returns an index corresponding to
+// a segment that observation is assigned to. The idea is
+// that outliers will get assigned different segment indices
+// than inliers, and inliers, in turn form long segments.
+//
+// So, given a sequence of observations, we get a sequence of segment
+// indices, one index per observation. In a second step, that sequence
+// can be parsed with a heuristic that identifies inlier segments.
+//
+// Template parameters:
+// A LocalModel type has the following methods:
+//
+//   // Adds a new item to the model and updates
+//   // the model in place to fit to that item, too.
+//   void insert(const T& x);
+//
+//   // Evalutes the fitness cost of the model
+//   // if we *would* insert x. (but doesn't insert it).
+//   double previewCost(const T& x) const;
+//
+// In the case of filtering GPS data, we could model the GPS trajectory
+// locally as the boat coordinates being second-order polynomial
+// functions of time, and only use the 12 last samples or so for fitting
+// that model.
+//
+// The type T is the type of observation. It could, for instance,
+// be a TimedValue<GeographicPosition<double>> in case we were to
+// filter GPS data.
+//
+// See the unit test for an example of how this class is used.
+template <typename T, typename LocalModel>
+class State {
+public:
+  State(
+      const Settings& settings,
+      const LocalModel& prototype)
+    : _settings(settings), _prototype(prototype) {
+      CHECK(0 < settings.maxLocalModelCost);
+      CHECK(0 < settings.maxLocalModelCount);
+  }
+
+  struct LocalState {
+    // The index of its associated segment.
+    int index = 0;
+
+    // The current local model.
+    LocalModel model;
+
+    // When the last update happened. Used to identify the oldest
+    // LocalState that we replace by a new one in case we need
+    // a new state.
+    int lastUpdate = 0;
+
+    // How many times we have inserted something.
+    int insertedCount = 0;
+
+    LocalState(
+        const LocalModel& prototype,
+        int i,
+        int itemCount, const T& x)
+      : model(prototype), lastUpdate(itemCount), index(i) {
+      model.insert(x);
+    }
+  };
+
+  struct Candidate {
+    LocalState* stateToUpdate = nullptr;
+    double selCost = std::numeric_limits<double>::infinity();
+
+    Candidate() {}
+    Candidate(double maxCost, LocalState* state, const T& x)
+        : stateToUpdate(state) {
+      auto nextCost = state->model.previewCost(x);
+
+      // Check if the fitness to the local model
+      // is good enough.
+      if (nextCost < maxCost) {
+
+        /*
+         * Here we decide how to choose the best state to
+         * update. For instance, we can choose the best fit. Or
+         * we can choose the longest segment.
+         *
+         * If we choose the longest segment we will greedily
+         * try to make long segments longer.
+         */
+        selCost = -state->insertedCount;
+      }
+    }
+
+    bool operator<(const Candidate& other) const {
+      return selCost < other.selCost;
+    }
+  };
+
+  Candidate getModelToUpdate(const T& x) {
+    Candidate best;
+    for (auto& m: _localStates) {
+      best = std::min(best,
+          Candidate(_settings.maxLocalModelCost,
+              &m, x));
+    }
+    return best;
+  }
+
+  // Inserts an item and assigns it to an existing or new segment.
+  int filter(const T& x) {
+    _itemCounter++;
+
+    // First try to see if there is already an acceptable local state,
+    // and in that case, choose the best state by some criterion.
+    auto best = getModelToUpdate(x);
+    if (best.stateToUpdate) {
+      auto& u = *(best.stateToUpdate);
+
+      // Actually insert it
+      u.model.insert(x);
+      u.lastUpdate = _itemCounter;
+      u.insertedCount++;
+      return u.index;
+    }
+
+    LocalState newState(
+        _prototype, _segmentCounter++, _itemCounter, x);
+    if (_localStates.size() < _settings.maxLocalModelCount) {
+      _localStates.push_back(newState);
+    } else {
+      _localStates[nextToReplace()] = newState;
+    }
+    return newState.index;
+  }
+private:
+  Settings _settings;
+  int _segmentCounter = 0;
+  int _itemCounter = 0;
+  LocalModel _prototype;
+  std::vector<LocalState> _localStates;
+
+  int nextToReplace() const {
+    return chooseNextToReplace([](LocalState s) {
+
+      // Not sure which rule is best to determine what to
+      // replace next.
+
+      //return s.insertedCount; // Shortest
+      return s.lastUpdate; // Oldest
+    });
+
+  }
+
+  int chooseNextToReplace(
+      std::function<double(LocalState)> f) const {
+    auto luAndIndex = std::make_pair(
+        std::numeric_limits<double>::infinity(), -1);
+    for (const auto& x: indexed(_localStates)) {
+      luAndIndex = std::min(luAndIndex, {f(x.second), x.first});
+    }
+    return luAndIndex.second;
+  }
+};
+
+struct IndexSpan {
+  Span<int> span;
+  int index = -1;
+};
+
+class IndexGrouper {
+public:
+  void insert(int index);
+  Array<IndexSpan> get();
+private:
+  int _counter = 0;
+  int _lastIndex = -1;
+  int _lastFrom = 0;
+  ArrayBuilder<IndexSpan> _groups;
+  void flush();
+};
+
+std::set<int> computeInlierSegments(
+    const Array<IndexSpan>& spans);
+
+}
+}
+
+
+
+
+
+
+#endif /* SERVER_MATH_SEQOUTLIERFILTER_H_ */

--- a/src/server/math/SeqOutlierFilterTest.cpp
+++ b/src/server/math/SeqOutlierFilterTest.cpp
@@ -1,0 +1,133 @@
+/*
+ * SeqOutlierFilterTest.cpp
+ *
+ *  Created on: 9 Jun 2017
+ *      Author: jonas
+ */
+#include <server/math/SeqOutlierFilter.h>
+#include <gtest/gtest.h>
+#include <server/common/math.h>
+#include <Eigen/Dense>
+#include <server/common/LineKM.h>
+
+using namespace sail;
+
+// This is a model of a short straight line.
+// Drawing a line through the two last observations,
+// it measures how well does the next observation fits to that line.
+class ShortStraightLineModel {
+public:
+  double previewCost(const Eigen::Vector2d& next) const {
+    if (counter < 2) {
+      return 0.0;
+    }
+
+    LineKM line(values[0](0), values[1](0),
+        values[0](1), values[1](1));
+    return sqr(line(next(0)) - next(1));
+  }
+
+  void insert(const Eigen::Vector2d value) {
+    values[0] = values[1];
+    values[1] = value;
+    counter++;
+  }
+private:
+  int counter = 0;
+  Eigen::Vector2d values[2];
+};
+
+std::pair<int, double> getDataWithOutliers(int index, double trueValue) {
+  if (7 <= index && index < 20) {
+    return {1, trueValue + 1000};
+  } else if ((index == 30) || (index == 40)) {
+    return {2, 90};
+  } else if (index < 300) {
+    return {0, trueValue};
+  }
+  return {3, trueValue};
+}
+
+double trueFunction(int index) {
+  return index < 300? 3.4*index - 23 : 56 - 0.1*index;
+}
+
+TEST(SeqOutlierFilterTest, ModelTest) {
+  ShortStraightLineModel model;
+
+  EXPECT_EQ(0.0, model.previewCost(Eigen::Vector2d(0, 0)));
+  EXPECT_EQ(0.0, model.previewCost(Eigen::Vector2d(1, 0.5)));
+  model.insert(Eigen::Vector2d(0, 0));
+  model.insert(Eigen::Vector2d(1.0, 0.5));
+  model.previewCost(Eigen::Vector2d(3.0, 1.5));
+}
+
+using namespace sail;
+using namespace SeqOutlierFilter;
+
+TEST(SeqOutlierFilterTest, ShortLineTest) {
+
+  Settings settings;
+  settings.maxLocalModelCost = 1.0;
+  settings.maxLocalModelCount = 20;
+  State<Eigen::Vector2d, ShortStraightLineModel> state(
+      settings, ShortStraightLineModel());
+
+  // Problem description:
+  // We have a curve that should be broken up into two sections.
+  // The first section is for the first 300 samples and is a straight
+  // line with slope 3.4 and offset -23. The second section is
+  // a straight line for the remaining samples from index 300,
+  // with slope -0.1 and offset 56.
+  //
+  // We have injected a few outliers in the data, and the objective
+  // of this code is to
+  //  (i) Assign segment indices to all the samples
+  // (ii) Determine which segment indices are likely corresponding
+  //      to inlier data.
+
+  // Part 1: Assign segment indices to every sample
+  IndexGrouper grouper;
+  int n = 400;
+  for (int i = 0; i < n; i++) {
+    auto indexAndValue = getDataWithOutliers(i, trueFunction(i));
+    auto expectedSegmentIndex = indexAndValue.first;
+    auto value = indexAndValue.second;
+    int segmentIndex = state.filter(Eigen::Vector2d(i, value));
+    EXPECT_EQ(expectedSegmentIndex, segmentIndex);
+    grouper.insert(segmentIndex);
+  }
+
+  // Part 2: Parse the sequence of segment indices
+  // to extract only inlier segments. We expect two sections,
+  // as described in the problem description.
+  auto inliers = computeInlierSegments(grouper.get());
+
+  EXPECT_EQ(inliers.size(), 2);
+  EXPECT_TRUE(inliers.count(0) == 1);
+  EXPECT_TRUE(inliers.count(3) == 1);
+}
+
+TEST(SeqOutlierFilterTest, IndexGrouperTest) {
+  IndexGrouper grouper;
+  grouper.insert(0);
+  grouper.insert(0);
+  grouper.insert(1);
+  grouper.insert(1);
+  grouper.insert(1);
+  grouper.insert(1);
+  grouper.insert(4);
+  auto groups = grouper.get();
+  EXPECT_EQ(3, groups.size());
+
+  int inds[3] = {0, 1, 4};
+  int froms[3] = {0, 2, 6};
+  int tos[3] = {2, 6, 7};
+  for (int i = 0; i < 3; i++) {
+    auto g = groups[i];
+    EXPECT_EQ(g.index, inds[i]);
+    EXPECT_EQ(g.span.minv(), froms[i]);
+    EXPECT_EQ(g.span.maxv(), tos[i]);
+  }
+}
+


### PR DESCRIPTION
This code could maybe be used to build a faster/more robust GPS filter. It identifies inliers and segments sequential data. The problem with the current GPS filter is that, although it seems to work, there are lots of arbitrary parameters making it hard to refactor it... This filter would also allow for some decoupling between identifying good data, and fitting a curve to the data.

Since adding this code is not urgent, feel free to close the PR. But I thought it would be nice to get it reviewed and have it in our code base.