### PR TITLE
Enable GPS output (RMC only) on NMEA0183 port

### DIFF
--- a/src/device/anemobox/anemonode/components/nmea0183port.js
+++ b/src/device/anemobox/anemonode/components/nmea0183port.js
@@ -46,6 +46,9 @@ function init(nmea0183PortPath, dataCb) {
             dataCb(data);
           }
         });
+        port.on('error', function(err) {
+          console.warn(err);
+        });
       }
     });
   });

--- a/src/device/anemobox/anemonode/components/pinconfig.js
+++ b/src/device/anemobox/anemonode/components/pinconfig.js
@@ -2,9 +2,9 @@ var fs = require('fs');
 
 function setPinOutput(pinNo, value) {
   var path = '/sys/kernel/debug/gpio_debug/gpio' + pinNo + '/';
-  fs.writeFile(path + 'current_pinmux', 'mode0', function() {});
-  fs.writeFile(path + 'current_direction', 'out', function() {});
-  fs.writeFile(path + 'current_value', value, function() {});
+  fs.writeFileSync(path + 'current_pinmux', 'mode0');
+  fs.writeFileSync(path + 'current_direction', 'out');
+  fs.writeFileSync(path + 'current_value', value);
 }
 
 module.exports.activateNmea0183 = function () {
@@ -17,5 +17,8 @@ module.exports.activateNmea0183 = function () {
   // For anemobox v1.1x
   // Let flow control make the port work.
   setPinOutput(129, 'high');
+  setInterval(function() {
+    setPinOutput(129, 'high');
+  }, 5000);
 };
 

--- a/src/device/anemobox/anemonode/main.js
+++ b/src/device/anemobox/anemonode/main.js
@@ -11,7 +11,7 @@ var withGps = true;
 var withTimeEstimator = true;
 var withSetTime = true;
 var withBT = false;
-var echoGpsOnNmea = false;
+var echoGpsOnNmea = true;
 var withEstimator = true;
 var logInternalGpsNmea = false;
 var logExternalNmea = true;
@@ -98,9 +98,12 @@ dispatcher.setSourcePriority("NMEA2000/0", -10);
 
 // Internal GPS with output to NMEA0183
 var gps = (withGps ?  require('./components/gps') : {readGps:function(){}});
+var rmcExpr = /\$GNRMC(,[^*]*)*\*[A-Z0-9]{2}/g;
+
 function gpsData(data) {
   if (echoGpsOnNmea) {
-    nmea0183port.emitNmea0183Sentence(data);
+    var s = (data + '').match(rmcExpr).join('\r\n')+'\r\n';
+    nmea0183port.emitNmea0183Sentence(s);
   }
   if (withLogger && logInternalGpsNmea) {
     logger.logText("Internal GPS NMEA", data.toString('ascii'));

--- a/src/device/anemobox/anemonode/run.sh
+++ b/src/device/anemobox/anemonode/run.sh
@@ -17,6 +17,10 @@ fi
 
 ./format.sh
 
+# make sure NMEA0183 output works on anemobox v1.x
+echo mode0 > /sys/kernel/debug/gpio_debug/gpio129/current_pinmux 
+echo high > /sys/kernel/debug/gpio_debug/gpio129/current_value
+
 systemctl restart avahi-daemon
 
 ps aux | grep -v grep | grep -q jacd || ./start_n2k.sh


### PR DESCRIPTION
I tested this on both the old and the new versions of our electronics. It works.