### PR TITLE
Get rid of code that doesn't work

### DIFF
--- a/src/server/common/string.cpp
+++ b/src/server/common/string.cpp
@@ -161,17 +161,6 @@ std::string toLower(const std::string &src) {
 }
 
 
-std::string int64ToHex(int64_t x) {
-  constexpr int len = 2*sizeof(x);
-  std::string result(len, '0');
-  for (int i = 0; i < sizeof(x); ++i) {
-    int offs = 2*i;
-    result[offs + 0] = toHexDigit((x >> ((15 - i) * 8 + 4)) & 0xf);
-    result[offs + 1] = toHexDigit((x >> ((15 - i) * 8)) & 0xf);
-  }
-  return result;
-}
-
 void splitFilenamePrefixSuffix(const std::string &filename,
                                std::string &prefix, std::string &suffix) {
   int index = filename.find_last_of('.');

--- a/src/server/common/string.h
+++ b/src/server/common/string.h
@@ -37,7 +37,6 @@ void toLowerInPlace(std::string &data);
 std::string toLower(const std::string &src);
 void splitFilenamePrefixSuffix(const std::string &filename,
                                std::string &prefix, std::string &suffix);
-std::string int64ToHex(int64_t x);
 void indent(std::ostream *s, int count);
 
 std::string readFileToString(const std::string& filename);

--- a/src/server/common/stringTest.cpp
+++ b/src/server/common/stringTest.cpp
@@ -34,19 +34,6 @@ TEST(StringTest, FormatTest) {
   EXPECT_EQ(result, "Nine is 9");
 }
 
-TEST(StringTest, Int64Test) {
-  int64_t x = 0x1234567890ABCDEF;
-  EXPECT_EQ("1234567890ABCDEF", int64ToHex(x));
-}
-
-TEST(StringTest, Int64TestOrdering) {
-  int64_t a = 234;
-  int64_t b = 3456;
-
-  EXPECT_LE(a, b);
-  EXPECT_LE(int64ToHex(a), int64ToHex(b));
-}
-
 TEST(StringTetst, joinTest) {
   EXPECT_EQ("a+b+c", join(std::vector<std::string>{"a", "b", "c"}, "+"));
   EXPECT_EQ("a", join(std::vector<std::string>{"a"}, "\n"));

--- a/src/server/nautical/Nav.cpp
+++ b/src/server/nautical/Nav.cpp
@@ -49,16 +49,6 @@ HorizontalMotion<double> Nav::gpsMotion() const {
   return HorizontalMotion<double>::polar(gpsSpeed(), gpsBearing());
 }
 
-Nav::Id Nav::id() const {
-  if (hasId()) {
-    int64_t time = _time.toMilliSecondsSince1970();
-    static_assert(sizeof(time) == 8, "The size of the time datatype seems to have changed.");
-    return _boatId + int64ToHex(time);
-  } else {
-    return "";
-  }
-}
-
 bool Nav::hasId() const {
   return hasBoatId() && _time.defined();
 }

--- a/src/server/nautical/Nav.h
+++ b/src/server/nautical/Nav.h
@@ -99,7 +99,6 @@ class Nav {
   // TODO: Require this method to return true before a Nav is inserted to a database.
   bool isIndexed() const {return hasId() && hasBoatId();}
 
-  Id id() const;
   bool hasId() const;
   const Id &boatId() const {return _boatId;}
 


### PR DESCRIPTION
After upgrading and reinstalling lots of stuff on my Mac, I discovered that ```common_stringTest``` failed for ```int64ToHex```. I wasn't able to figure out the bug, it was that kind of bug that disappears when you add an ```std::cout...```. So I removed the code and the code that depends on it.