### PR TITLE
Add node-gyp glue code to export NMEA2000 packets.

### DIFF
--- a/src/device/anemobox/Nmea2000Source.cpp
+++ b/src/device/anemobox/Nmea2000Source.cpp
@@ -27,6 +27,15 @@ void Nmea2000Source::process(const std::string& srcName,
   pushAndLinkPacket(packet);
 }
 
+std::vector<std::vector<uint8_t>> Nmea2000Source::exportPackets(int pgn) const {
+  // TODO: 
+  // 1. Call the exportPacket(pgn) method of the PgnVisitor class
+  //    (base of this classe).
+  // 2. Split it using the FastPacketSplitter (can be instance variable
+  //    of this class). Only split if isFastPacket(pgn).
+  return {};
+}
+
 bool Nmea2000Source::apply(const PgnClasses::CanPacket &c, const PgnClasses::VesselHeading& packet) {
   if (!packet.valid()
       || !packet.heading().defined()) { return false; }

--- a/src/device/anemobox/Nmea2000Source.h
+++ b/src/device/anemobox/Nmea2000Source.h
@@ -5,6 +5,7 @@
 
 #include <device/anemobox/Dispatcher.h>
 #include <device/anemobox/n2k/PgnClasses.h>
+#include <device/anemobox/n2k/CanPacket.h>
 
 namespace sail {
 
@@ -18,7 +19,12 @@ class Nmea2000Source : public PgnClasses::PgnVisitor {
                const unsigned char* buffer,
                int length,
                int srcAddr);
+
+	std::vector<std::vector<uint8_t>> exportPackets(int pgn) const;
  protected:
+  // TODO: Override the exportPacket methods here for the different
+  // packet types.
+
   bool apply(const PgnClasses::CanPacket &c, const PgnClasses::VesselHeading& packet) override;
   bool apply(const PgnClasses::CanPacket &c, const PgnClasses::Speed& packet) override;
   bool apply(const PgnClasses::CanPacket &c, const PgnClasses::GnssPositionData& packet) override;

--- a/src/device/anemobox/anemonode/src/JsNmea2000Source.h
+++ b/src/device/anemobox/anemonode/src/JsNmea2000Source.h
@@ -17,7 +17,7 @@ class JsNmea2000Source : public Nan::ObjectWrap {
  protected:
   static NAN_METHOD(New);
   static NAN_METHOD(process);
-
+  static NAN_METHOD(exportPackets);
  private:
   sail::Nmea2000Source _nmea2000;
 };

--- a/src/device/anemobox/anemonode/test/testExportPacket.js
+++ b/src/device/anemobox/anemonode/test/testExportPacket.js
@@ -1,0 +1,36 @@
+var anemonode = require('../build/Release/anemonode');
+var assert = require('assert');
+
+var n2ksrc = new anemonode.Nmea2000Source();
+
+function expectError(f) {
+  var caught = false;
+  try {
+    f();
+  } catch (e) {
+    caught = true;
+  }
+  assert(caught);
+}
+
+describe('JsNmea2000Source::Export', function() {
+  it('exportPackets', function() {
+    var packets = n2ksrc.exportPackets(129029);
+
+    // When running the unit tests, we are probably
+    // not connected, so we will not get any packets.
+    assert(packets.length == 0);
+
+    // TODO: Test more things...
+  });
+  
+  it('exportPackets, bad calls', function() {
+    expectError(function() {
+      n2ksrc.exportPackets();
+    });
+
+    expectError(function() {
+      n2ksrc.exportPackets("kattskit");
+    });
+  });
+});


### PR DESCRIPTION
We might later want to see if we can reduce the number of copies of ```std::vector<uint8_t>``` if that would be perceived as a problem.