### PR TITLE
export angles in range [0, 360[ or ]-180, 180] depending on type

### DIFF
--- a/src/server/nautical/tiles/ChartTiles.cpp
+++ b/src/server/nautical/tiles/ChartTiles.cpp
@@ -212,7 +212,7 @@ std::shared_ptr<bson_t> chartTileToBson(const ChartTile<T> tile,
   StatArrays arrays;
 
   for (const TimedValue<Statistics<T>>& stats : tile.samples) {
-    stats.value.appendToArrays(&arrays);
+    stats.value.appendToArrays(data.what, &arrays);
   }
 
   bsonAppendCollection(result.get(), "mean", arrays.mean);


### PR DESCRIPTION
Alinghi complained that twdir and heading is expressed in -180, 180 range.
This fixes the problem.