### PR TITLE
Avoid data loops by removing Anemomind estimator source

### DIFF
--- a/src/server/nautical/BoatLogProcessor.cpp
+++ b/src/server/nautical/BoatLogProcessor.cpp
@@ -362,7 +362,9 @@ bool BoatLogProcessor::process(ArgMap* amap) {
   hack::SelectSources(&current);
   current = current.createMergedChannels(
       std::set<DataCode>{AWA, AWS}, Duration<>::seconds(.3));
-  std::shared_ptr<HTree> fulltree = _grammar.parse(current);
+  std::shared_ptr<HTree> fulltree = _grammar.parse(
+      current.stripSource("Anemomind estimator") // avoid "loop back" effects
+      );
 
   if (!fulltree) {
     LOG(WARNING) << "grammar parsing failed. No data? boat: " << _boatid;

--- a/src/server/nautical/NavDataset.cpp
+++ b/src/server/nautical/NavDataset.cpp
@@ -233,6 +233,27 @@ NavDataset NavDataset::clone() const {
   return r;
 }
 
+NavDataset NavDataset::stripSource(const std::string& source) const {
+  if (_dispatcher == nullptr) {
+    return NavDataset();
+  }
+
+  NavDataset r(
+      cloneAndfilterDispatcher(
+          _dispatcher.get(),
+          [source](DataCode testedCode, const std::string& s) {
+            return s != source;
+          }),
+      _lowerBound,
+      _upperBound);
+  for (auto s : _activeSource) {
+    if (s.second->source() != source) {
+      r._activeSource[s.first] = s.second;
+    }
+  }
+  return r;
+}
+
 NavDataset NavDataset::stripChannel(DataCode code) const {
   if (_dispatcher == nullptr) {
     return NavDataset();

--- a/src/server/nautical/NavDataset.h
+++ b/src/server/nautical/NavDataset.h
@@ -222,6 +222,7 @@ public:
   NavDataset clone() const;
 
   NavDataset stripChannel(DataCode code) const;
+  NavDataset stripSource(const std::string& source) const;
 
   bool hasLowerBound() const;
   bool hasUpperBound() const;


### PR DESCRIPTION
If Anemomind estimator is wrong for a reason or another,
grammar parsing should not rely on it to do its job.

Otherwise, wrong calib -> wrong grammar -> wrong calib...
the loop never ends.