### PR TITLE
Soften the minor state cost

### DIFF
--- a/src/server/nautical/grammars/WindOrientedGrammar.h
+++ b/src/server/nautical/grammars/WindOrientedGrammar.h
@@ -12,6 +12,7 @@
 
 namespace sail {
 
+double computeMinorStateCost(double twaDegs, int minorState);
 
 struct WindOrientedGrammarSettings {
   WindOrientedGrammarSettings();

--- a/src/server/nautical/grammars/WindOrientedGrammarTest.cpp
+++ b/src/server/nautical/grammars/WindOrientedGrammarTest.cpp
@@ -66,6 +66,17 @@ namespace {
   }
 }
 
+TEST(WindOrientedGrammarTest, SoftStateCost) {
+  //double computeMinorStateCost(double twaDegs, int minorState);
+  EXPECT_NEAR(computeMinorStateCost(0.0, 0), 0.0, 1.0e-6);
+  EXPECT_NEAR(computeMinorStateCost(120, 1), 0.0, 1.0e-6);
+  EXPECT_NEAR(computeMinorStateCost(150, 1), 1.0, 1.0e-6);
+  EXPECT_NEAR(computeMinorStateCost(135, 1), 0.5, 1.0e-6);
+  EXPECT_NEAR(computeMinorStateCost(15, 5), 0.5, 1.0e-6);
+  EXPECT_NEAR(computeMinorStateCost(15 + 720, 5), 0.5, 1.0e-6);
+  EXPECT_NEAR(computeMinorStateCost(15 - 720, 5), 0.5, 1.0e-6);
+}
+
 TEST(WindOrientedGrammarTest, Hinting) {
   Poco::Path path = PathBuilder::makeDirectory(Env::SOURCE_DIR)
     .pushDirectory("datasets")


### PR DESCRIPTION
With these changes, we get 22 maneuvers instead of just 5 maneuvers when running on June 2nd for the boat ETF mentioned in issue #1299 .