### PR TITLE
Use normal _id in charttiles, stream csv export

### DIFF
--- a/www2/package.json
+++ b/www2/package.json
@@ -30,7 +30,7 @@
     "method-override": "~2.3.10",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
-    "mongoose": "~5.1.2",
+    "mongoose": "~5.2.7",
     "morgan": "^1.7.0",
     "multer": "^1.3.0",
     "nodemailer": "^4.6.5",

--- a/www2/server/api/chart/chart.controller.js
+++ b/www2/server/api/chart/chart.controller.js
@@ -6,13 +6,13 @@ var ChartSource = require('./chartsource.model');
 var mongoose = require('mongoose');
 
 var makeQuery = function(boatId, zoom, tile, channel, source) {
-  return {_id: {
+  return {
     boat : mongoose.Types.ObjectId(boatId),
     zoom: parseInt(zoom),
     tileno: parseInt(tile),
     what: channel || '',
     source: source || ''
-  }};
+  };
   return obj;
 };
 
@@ -23,8 +23,7 @@ exports.retrieve = function(req, res, next) {
                         req.params.channel,
                         req.params.source);
 
-  // The query bypasses mongoose. It does not like having an object
-  // as _id.
+  // The query bypasses mongoose.
   ChartTile.collection.find(query).toArray(function(err, tiles) {
     if (err) {
       return next(err);
@@ -37,8 +36,8 @@ exports.retrieve = function(req, res, next) {
 };
 
 function sampleTime(tile, sampleno) {
-  return new Date((tile._id.tileno << tile._id.zoom)
-                  + (sampleno / tile.samples.length) * (1 << tile._id.zoom));
+  return new Date((tile.tileno << tile.zoom)
+                  + (sampleno / tile.samples.length) * (1 << tile.zoom));
 }
 
 

--- a/www2/server/api/chart/charttile.model.js
+++ b/www2/server/api/chart/charttile.model.js
@@ -4,13 +4,12 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
   
 var ChartTileSchema = new Schema({
-    _id: {
-      boat: Schema.ObjectId,
-      zoom: Number,
-      tileno: Number,
-      what: String,
-      source: String
-      },
+    boat: Schema.ObjectId,
+    zoom: Number,
+    tileno: Number,
+    what: String,
+    source: String,
+
     samples: {
       count: Number,
       mean: Number,

--- a/www2/server/api/export/export.controller.js
+++ b/www2/server/api/export/export.controller.js
@@ -1,8 +1,15 @@
 
 var mongoose = require('mongoose');
 var ChartTile = require('../chart/charttile.model');
+var ObjectId = mongoose.Types.ObjectId;
+var strftime = require('./strftime');
 
 var dateLength = '2016-09-14T16:25:26'.length;
+
+ // These values should match those in CharTiles.h
+const minZoom = 9;
+const maxZoom = 28;
+const samplesPerTile = 512;
 
 function pad(num, size) {
   var s = num+"";
@@ -11,6 +18,9 @@ function pad(num, size) {
 }
 
 function formatTime(date) {
+  // 06/20/2018 4:26:35 PM
+  return strftime("%m/%d/%Y %l:%M:%S %p", date);
+  /* The following is the reference implementation, but it is too slow.
   return date.toLocaleString('en-US', {
     year: 'numeric',
     month: '2-digit',
@@ -21,6 +31,7 @@ function formatTime(date) {
     hour12: true,
     timeZone: 'UTC'
   }).replace(/,/, '');
+  */
 }
 
 function getColumn (columns, title) {
@@ -39,6 +50,9 @@ function getRow(table, timeSec) {
 }
 
 function csvEscape(s) {
+  if (!s) {
+    return '"-"';
+  }
   return '"' + s.replace(/"/g, '""').replace(/,/g,';') + '"';
 }
 
@@ -80,11 +94,13 @@ function formatColumnEntry(type, entry) {
 }
 
 
-function sendCsv(res, columns, table, columnType) {
-  var row = [ "DATE/TIME(UTC)" ];
-  for (var c in columns) { row[1 + columns[c]] = csvEscape(c); }
+function sendCsvHeader(res, columns) {
+  var row = [ "DATE/TIME(UTC)" ].concat(columns).map(csvEscape);
   res.write(row.join(',') + '\n');
-  var numCols = row.length;
+}
+
+function sendCsvChunk(res, columns, table, columnType) {
+  var numCols = 1 + columns.length;
 
   var times = Object.keys(table);
   times.sort(function(a, b) { return parseInt(a) - parseInt(b); });
@@ -103,10 +119,145 @@ function sendCsv(res, columns, table, columnType) {
     res.write(row.join(', ') + '\n');
   }
 }
-    
+
+var listChannelsWithSources = function(boat, zoom, firstTile, lastTile, cb) {
+  ChartTiles.aggregate([
+    {
+      $match: {
+        boat: ObjectId(boat),
+        zoom: zoom,
+        tileno: { $gte: firstTile, $lte: lastTile }
+      },
+    }, {
+      $group: {
+        _id: { what: "$what", source: "$source" },
+        total: { $sum: 1 }
+      }
+    }, {
+      $group: {
+        _id: "$_id.what",
+        sources: { $push: "$_id.source" }
+      }
+    }, {
+      $project: {
+        _id: false,
+        what: "$_id",
+        sources: true
+      }
+    }, {
+      $sort: {what: 1}
+    }
+  ]).exec(cb);
+};
+
+var listColumns = function(boat, zoom, firstTile, lastTile, cb) {
+  ChartTile.aggregate([
+    {
+      $match: {
+        boat: ObjectId(boat),
+        zoom: zoom,
+        tileno: { $gte: firstTile, $lte: lastTile }
+      },
+    }, {
+      $group: {
+        _id: { what: "$what", source: "$source" },
+      }
+    }, {
+      $sort: { _id: 1 }
+    }
+  ]).exec(function(err, res) {
+    if (err) {
+      cb(err);
+    } else {
+      cb(undefined, res.map(function(e) {
+        return e._id.what + ' - ' + e._id.source;
+      }));
+    }
+  });
+};
+ 
+function sendCsvWithColumns(start, end, boat, zoom, firstTile, lastTile,
+                            columns, res, timeRange) {
+  var query = {
+    boat: mongoose.Types.ObjectId(boat),
+    zoom: zoom,
+    tileno: {
+      "$gte": firstTile,
+      "$lte": lastTile
+    }
+  };
+
+  console.warn(query);
+
+  var table = { };
+  var columnType = { };
+
+  var resultSent = false;
+
+  var currentTile = firstTile;
+
+  res.contentType('text/csv');
+  res.header("Content-Disposition", "attachment;filename=" + timeRange + ".csv");
+  sendCsvHeader(res, columns);
+
+  // The query bypasses mongoose.
+  ChartTile.collection
+    .find(query)
+    // see https://docs.mongodb.com/manual/tutorial/sort-results-with-indexes/
+    .sort({ boat:1, zoom:1, tileno: 1})
+    .forEach(function(tile) {
+      var columnTitle = tile.what + ' - ' + tile.source;
+      var firstTime = new Date(1000 * tile.tileno * (1 << tile.zoom));
+
+      if (tile.tileno > currentTile) {
+        sendCsvChunk(res, columns, table, columnType);
+        currentTile = tile.tileno;
+        table = { };
+        columnType = { };
+      }
+
+      // increment between samples in s
+      var increment = (1 << tile.zoom) / samplesPerTile;
+      var firstTimeSec = Math.floor(firstTime / 1000);
+      var startTimeSec = start.getTime() / 1000;
+      var endTimeSec = end.getTime() / 1000;
+
+      var colno = columns.indexOf(columnTitle);
+      if (colno < 0) {
+        return;
+      }
+      columnType[colno] = tile.what;
+      for (var i = 0; i < samplesPerTile; ++i) {
+        if (tile.count && tile.count[i] > 0) {
+          var time = firstTimeSec + i * increment;
+          if (time > startTimeSec && time < endTimeSec) {
+            var row = getRow(table, time);
+            row[colno] = tile.mean[i];
+          }
+        }
+      }
+
+      if (resultSent) {
+        console.warn('ERROR! received DB data to build an reply that has been sent already!');
+        console.warn(new Error().stack);
+      }
+    },
+    function(err) {
+      if (err) {
+        res.status(500).send();
+      } else {
+        setTimeout(function() {
+          resultSent = true;
+          sendCsvChunk(res, columns, table, columnType);
+          res.status(200).end();
+        }, 1);
+      }
+    });
+}
+
 exports.exportCsv = function(req, res, next) {
   var timeRange = req.params.timerange;
-  var boat = req.params.boat;
+  var boat = req.params.boat + '';
   if (typeof(timeRange) != 'string' || timeRange.length != 2 * dateLength) {
     return res.status(400).send();
   }
@@ -119,103 +270,25 @@ exports.exportCsv = function(req, res, next) {
   // Fixed for now, might be configurable by the user later.
   var frequency = 1; // Hz
 
-   // These values should match those in CharTiles.h
-  var minZoom = 9;
-  var maxZoom = 28;
-  var samplesPerTile = 512;
-
   var zoom = Math.log2(samplesPerTile / frequency)
 
   var tileNo = function(date, rounding) {
     return Math[rounding](date.getTime() / 1000 / (1 << zoom));
   };
 
-  // The following query fetches all data for a given tile:
-  // db.charttiles.find({_id: {
-  //   $gt: {
-  //     "boat" : ObjectId("552b806a35ce7cb254dc9515"),
-  //     "zoom" : 9,
-  //     "tileno" : NumberLong(2799447),
-  //     what: '',
-  //     source: ''
-  //   },
-  //   $lt: {
-  //     "boat" : ObjectId("552b806a35ce7cb254dc9515"),
-  //     "zoom" : 9,
-  //     "tileno" : NumberLong(2799447),
-  //     what: 'zzz',
-  //     source: 'zzz'
-  //  } } }).forEach(function(t) { print(t._id.what +': ' + t._id.source); });
+  var firstTile = tileNo(start, 'floor');
+  var lastTile = tileNo(end, 'ceil');
 
-  var query = {
-    _id: {
-      $gt: {
-        boat: mongoose.Types.ObjectId(boat),
-        zoom: zoom,
-        tileno: tileNo(start, 'floor'),
-        what: '',
-        source: ''
-      },
-      $lt: {
-        boat: mongoose.Types.ObjectId(boat),
-        zoom: zoom,
-        tileno: tileNo(end, 'ceil'),
-        what: 'zzz',
-        source: 'zzz'
-      }
-    }
-  };
-
-  var columns = { };
-  var table = { };
-  var columnType = { };
-
-  var resultSent = false;
-
-  // The query bypasses mongoose. It does not like having an object
-  // as _id.
-  ChartTile.collection.find(query).forEach(function(tile) {
-    var columnTitle = tile._id.what + ' - ' + tile._id.source;
-    var firstTime = new Date(1000 * tile._id.tileno * (1 << tile._id.zoom));
-
-    // increment between samples in s
-    var increment = (1 << tile._id.zoom) / samplesPerTile;
-    var firstTimeSec = Math.floor(firstTime / 1000);
-    var startTimeSec = start.getTime() / 1000;
-    var endTimeSec = end.getTime() / 1000;
-
-    var colno = getColumn(columns, columnTitle);
-    columnType[colno] = tile._id.what;
-    for (var i = 0; i < samplesPerTile; ++i) {
-      if (tile.count && tile.count[i] > 0) {
-        var time = firstTimeSec + i * increment;
-        if (time > startTimeSec && time < endTimeSec) {
-          var row = getRow(table, time);
-          row[colno] = tile.mean[i];
-        }
-      }
-    }
-
-    if (resultSent) {
-      console.warn('ERROR! received DB data to build an reply that has been sent already!');
-      console.warn(new Error().stack);
-    }
-  },
-  function(err) {
-    if (err) {
-      res.status(500).send();
-    } else {
-      if (Object.keys(columns).length == 0) {
+  listColumns(boat, zoom, firstTile, lastTile,
+    function(err, columns) {
+      if (err) {
+        console.warn(err);
+        res.status(500).send();
+      } else if (columns.length == 0) {
         res.status(404).send();
       } else {
-        setTimeout(function() {
-          res.contentType('text/csv');
-          res.header("Content-Disposition", "attachment;filename=" + timeRange + ".csv");
-          resultSent = true;
-          sendCsv(res, columns, table, columnType);
-          res.status(200).end();
-        }, 1);
+        sendCsvWithColumns(start, end, boat, zoom, firstTile, lastTile,
+                           columns, res, timeRange);
       }
-    }
-  });
-}
+    });
+};

--- a/www2/server/api/export/strftime.js
+++ b/www2/server/api/export/strftime.js
@@ -1,0 +1,95 @@
+/* Port of strftime(). Compatibility notes:
+ *
+ * %c - formatted string is slightly different
+ * %D - not implemented (use "%m/%d/%y" or "%d/%m/%y")
+ * %e - space is not added
+ * %E - not implemented
+ * %h - not implemented (use "%b")
+ * %k - space is not added
+ * %n - not implemented (use "\n")
+ * %O - not implemented
+ * %r - not implemented (use "%I:%M:%S %p")
+ * %R - not implemented (use "%H:%M")
+ * %t - not implemented (use "\t")
+ * %T - not implemented (use "%H:%M:%S")
+ * %U - not implemented
+ * %W - not implemented
+ * %+ - not implemented
+ * %% - not implemented (use "%")
+ *
+ * strftime() reference:
+ * http://man7.org/linux/man-pages/man3/strftime.3.html
+ *
+ * Day of year (%j) code based on Joe Orost's answer:
+ * http://stackoverflow.com/questions/8619879/javascript-calculate-the-day-of-the-year-1-366
+ *
+ * Week number (%V) code based on Taco van den Broek's prototype:
+ * http://techblog.procurios.nl/k/news/view/33796/14863/calculate-iso-8601-week-and-year-in-javascript.html
+ */
+module.exports = function (sFormat, date) {
+  if (!(date instanceof Date)) date = new Date();
+  var nDay = date.getUTCDay(),
+    nDate = date.getUTCDate(),
+    nMonth = date.getUTCMonth(),
+    nYear = date.getUTCFullYear(),
+    nHour = date.getUTCHours(),
+    aDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+    aMonths = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
+    aDayCount = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334],
+    isLeapYear = function() {
+      return (nYear%4===0 && nYear%100!==0) || nYear%400===0;
+    },
+    getThursday = function() {
+      var target = new Date(date);
+      target.setDate(nDate - ((nDay+6)%7) + 3);
+      return target;
+    },
+    zeroPad = function(nNum, nPad) {
+      return ('' + (Math.pow(10, nPad) + nNum)).slice(1);
+    };
+  return sFormat.replace(/%[a-z]/gi, function(sMatch) {
+    return {
+      '%m': zeroPad(nMonth + 1, 2),
+      '%d': zeroPad(nDate, 2),
+      '%Y': nYear,
+      '%l': (nHour+11)%12 + 1,
+      '%M': zeroPad(date.getUTCMinutes(), 2),
+      '%S': zeroPad(date.getUTCSeconds(), 2),
+      '%p': (nHour<12) ? 'AM' : 'PM'
+
+      /*
+      '%I': zeroPad((nHour+11)%12 + 1, 2),
+      '%a': aDays[nDay].slice(0,3),
+      '%A': aDays[nDay],
+      '%b': aMonths[nMonth].slice(0,3),
+      '%B': aMonths[nMonth],
+      '%c': date.toUTCString(),
+      '%C': Math.floor(nYear/100),
+      '%e': nDate,
+      '%F': date.toISOString().slice(0,10),
+      '%G': getThursday().getFullYear(),
+      '%g': ('' + getThursday().getFullYear()).slice(2),
+      '%H': zeroPad(nHour, 2),
+      '%j': zeroPad(aDayCount[nMonth] + nDate + ((nMonth>1 && isLeapYear()) ? 1 : 0), 3),
+      '%k': '' + nHour,
+      '%P': (nHour<12) ? 'am' : 'pm',
+      '%s': Math.round(date.getTime()/1000),
+      '%u': nDay || 7,
+      '%V': (function() {
+              var target = getThursday(),
+                n1stThu = target.valueOf();
+              target.setMonth(0, 1);
+              var nJan1 = target.getDay();
+              if (nJan1!==4) target.setMonth(0, 1 + ((4-nJan1)+7)%7);
+              return zeroPad(1 + Math.ceil((n1stThu-target)/604800000), 2);
+            })(),
+      '%w': '' + nDay,
+      '%x': date.toLocaleDateString(),
+      '%X': date.toLocaleTimeString(),
+      '%y': ('' + nYear).slice(2),
+      '%z': date.toTimeString().replace(/.+GMT([+-]\d+).+/, '$1'),
+      '%Z': date.toTimeString().replace(/.+\((.+?)\)$/, '$1')
+      */
+    }[sMatch] || sMatch;
+  });
+}; 

--- a/www2/utilities/createMongoIndices.js
+++ b/www2/utilities/createMongoIndices.js
@@ -1,0 +1,3 @@
+// For chart tile random access and streaming for export
+db.charttiles.createIndex({boat: 1, zoom: 1, tileno:1, what:1, source: 1});
+


### PR DESCRIPTION
using a compound _id breaks mongo replication. This change
switches to a normal _id and a separate index.

CSV export is now streaming data, multiple days can be exported.

This is already in prod. Once this is reviewed, there will be another PR with other changes already in prod regarding the chart tiles.