### PR TITLE
Run c++ unit tests in docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.sconsign.dblite
 *.o
 build/
+build_docker
 *_build
 cpp/build
 src/device/Arduino/libraries/IreneTargetSpeed/test/test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ include("cmake/GTest.cmake")
 
 set(FULL_BUILD ON CACHE BOOL "enables full build or restrict to minimum")
 set(WITH_SAILROOT ON CACHE BOOL "Build the sailroot shared object to load in ROOT")
+if (WITH_SAILROOT)
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif(WITH_SAILROOT)
 
 find_package(Boost REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ WORKDIR /anemomind/build
 RUN cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo /anemomind
 
 # build prod dependencies only
-RUN make -j$(nproc) poco_ext gtest_ext ceres_ext mongo_ext
+RUN make -j$(nproc) poco_ext gtest_ext ceres_ext mongo_ext adolc_ext
 
 #copy all the code related to C++ : use .dockerignore for unwanted files
 RUN rm -rf /anemomind/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 
 # C++ Anemomind server MULTI STAGE BUILD
-FROM debian:10-slim as cppbuilder
+FROM debian:10-slim as build_env
 
 ARG LOAD_MONGO_DB
 ARG MONGO_URL
@@ -11,7 +11,7 @@ ENV MONGO_URL ${MONGO_URL}
 #  Clean up APT when done.
 RUN apt-get update && \
 	apt-get install --no-install-recommends -y base-files  bootlogd build-essential \
-    ca-certificates catdoc clang cmake dmidecode dstat ethstatus f2c file fio gdb git \
+    ca-certificates cmake dmidecode dstat ethstatus f2c file fio gdb git \
     gnupg grub-efi-amd64 haveged htop icu-devtools libarmadillo-dev libatlas3-base \
     libblas-dev libblocksruntime-dev libboost-dev libboost-filesystem-dev libboost-iostreams-dev \
     libboost-regex-dev libboost-system-dev libboost-thread-dev libbsd-dev libcairo2-dev \
@@ -19,12 +19,14 @@ RUN apt-get update && \
     libhogweed4 libicu-dev libicu63 libidn11 libidn2-0 liblapack-dev libncurses5-dev libnettle6 \
     libnss-myhostname libp11-kit0 libprotobuf-dev libpsl5 libsqlite3-dev libssl-dev libsuitesparse-dev \
     libsystemd0 libtasn1-6 libudev1 libunistring2 libxml2-dev locales locate lsb-release lsof make \
-    man-db mg mosh mutt net-tools netcat ninja-build pkg-config protobuf-compiler pstack rsync rsyslog \
-    shunit2 socat ssh swift swig sysstat systemd-sysv systemtap-sdt-dev tcpdump tinc tmux traceroute \
+    net-tools netcat ninja-build pkg-config protobuf-compiler pstack rsync rsyslog \
+    ssh sysstat systemd-sysv systemtap-sdt-dev tinc tmux traceroute \
     tzdata unattended-upgrades uuid-dev uuid-runtime wget whiptail xfsprogs libeigen3-dev && \
     apt-get clean autoclean && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+FROM build_env as basebuild
 
 # Copy cmake structure, without source code so that we can build and cache
 # dependencies
@@ -35,22 +37,31 @@ RUN mkdir /anemomind/src && echo > /anemomind/src/CMakeLists.txt
 RUN mkdir -p /anemomind/build
 WORKDIR /anemomind/build
 RUN cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo /anemomind
-RUN make -j4 poco_ext gtest_ext ceres_ext
+
+# build prod dependencies only
+RUN make -j$(nproc) poco_ext gtest_ext ceres_ext mongo_ext
 
 #copy all the code related to C++ : use .dockerignore for unwanted files
 RUN rm -rf /anemomind/src
 COPY ./src /anemomind/src
+RUN make rebuild_cache
 
-# compile link and copy the bin with dependencies to /tmp/
-# we need to do it as one RUN command since the products of the workdir are temp
-# for this intermediate container (layer)
-# Use of J1 can be an arg ?
+# compile and link prod binaries.
+RUN make -j$(nproc) nautical_processBoatLogs logimport_summary \
+    anemobox_logcat logimport_try_load nautical_catTargetSpeed
 
-#RUN cmake .. -DCMAKE_BUILD_TYPE=RelWidthDebInfo \
-#    && make -j1 nautical_processBoatLogs logimport_summary anemobox_logcat logimport_try_load nautical_catTargetSpeed
+# to compile and execute unit tests, do:
+# docker build --target=unit_tester .
+FROM basebuild as unit_tester
 
-RUN make rebuild_cache && make -j4 nautical_processBoatLogs logimport_summary anemobox_logcat logimport_try_load nautical_catTargetSpeed
+WORKDIR /anemomind/build
+RUN make -j$(nproc) && make -j$(nproc) test
 
+FROM basebuild as anemomind_prod
+
+# Copy the prod bins with dependencies to /tmp/
+# we need to do it as one RUN command since the products of the workdir are
+# temp for this intermediate container (layer)
 WORKDIR /anemomind/build
 RUN mkdir -p /temp/lib \
     && mkdir -p /temp/bin \
@@ -80,7 +91,8 @@ EXPOSE 22
 CMD ["/usr/sbin/sshd", "-D"]
 
 # now start from a lean image and copy all the needed bin/libs only
-FROM debian:10-slim
+# build with docker build --target=anemomind_prod
+FROM debian:10-slim as anemomind_prod
 
 ARG MONGO_URL
 ENV MONGO_URL ${MONGO_URL}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 
 # C++ Anemomind server MULTI STAGE BUILD
-FROM debian:10-slim as build_env
+FROM debian:bullseye-slim as build_env
 
 ARG LOAD_MONGO_DB
 ARG MONGO_URL
@@ -16,7 +16,7 @@ RUN apt-get update && \
     libblas-dev libblocksruntime-dev libboost-dev libboost-filesystem-dev libboost-iostreams-dev \
     libboost-regex-dev libboost-system-dev libboost-thread-dev libbsd-dev libcairo2-dev \
     libcurl4-openssl-dev libcxsparse3 libedit-dev libffi6 libgmp10 libgnutls30 \
-    libhogweed4 libicu-dev libicu63 libidn11 libidn2-0 liblapack-dev libncurses5-dev libnettle6 \
+    libicu-dev libicu63 libidn11 libidn2-0 liblapack-dev libncurses5-dev \
     libnss-myhostname libp11-kit0 libprotobuf-dev libpsl5 libsqlite3-dev libssl-dev libsuitesparse-dev \
     libsystemd0 libtasn1-6 libudev1 libunistring2 libxml2-dev locales locate lsb-release lsof make \
     net-tools netcat ninja-build pkg-config protobuf-compiler pstack rsync rsyslog \

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ This repository holds the code for
 
 In ```anemomind-ios```, you will find the code for iOS devices.
 
+# Using docker for development
+
+The following command will build a docker image and compile all the c++ code.
+```
+./src/compile_in_docker.sh
+```
+
 # Using the Vagrant box for development
 ```
 vagrant up

--- a/src/compile_and_test.sh
+++ b/src/compile_and_test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_SAILROOT=OFF
+
+# build dependencies
+make help | grep ext | sed 's/\.\.\. //' | grep -v gflags | xargs $RUN make -j$(nproc)
+
+make -j$(nproc)
+make -j$(nproc) test

--- a/src/compile_in_docker.sh
+++ b/src/compile_in_docker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# The -i (interactive) option allows user to hit CTRL-C to stop the build.
+"${DIR}/docker_run.sh" -i ../src/compile_and_test.sh

--- a/src/docker_run.sh
+++ b/src/docker_run.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+# Determine where is the root of the project based on where this script is
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null 2>&1 && pwd )"
+
+# Everything starting with a '-' before the executable itself is considered as an argument for docker
+DOCKER_ARGS=""
+while [[ "$1" == "-"* ]] ; do
+  DOCKER_ARGS="${DOCKER_ARGS} $1"
+  shift
+done
+
+if [[ "$1" == "" ]] ; then 
+  echo "Usage: $0 <docker options> <path to executable>"
+  echo "note that the executable path is relative to the build directory within the docker image."
+  exit 1
+fi
+
+# Make sure the docker image is up to date
+docker build --target=build_env -t anemomind_build_env "${ROOT}"
+
+# Create the build folder if needed
+mkdir -p "${ROOT}/build_docker"
+
+# Setting the home dir is required because some make install scripts create a ~/.cmake directory
+docker run $DOCKER_ARGS -v "${ROOT}:/anemomind" -w /anemomind/build_docker \
+         -u $(id -u):$(id -g)  -e HOME=/anemomind/build_docker anemomind_build_env $*
+

--- a/src/server/nautical/tiles/MongoNavDatasetLoaderTest.cpp
+++ b/src/server/nautical/tiles/MongoNavDatasetLoaderTest.cpp
@@ -17,12 +17,11 @@ TEST(MongoNavDatasetLoader, TestIt) {
       mongoc_uri,
       mongoc_uri_new(MongoDBConnection::defaultMongoUri())));
 
-  if (!db.defined()) {
+  if (!db.connected()) {
     LOG(WARNING) << "The Mongo database does not seem to be running";
     // If the Mongo server is not running, it is not a bug in our code.
     return;
   }
-  LOG(INFO) << "Successfully connected";
 
   std::string boatId = "58c2d60d481c472292864b05";
   {
@@ -46,7 +45,13 @@ TEST(MongoNavDatasetLoader, TestIt) {
           &toRemove,
           nullptr,
           &removeError)) {
-        LOG(WARNING) << "Failed to remove because: " << removeError.message;
+        if (removeError.code == 13053) {
+          LOG(WARNING) <<" mongo serveur not running. Skipping mongo tests.";
+          return;
+        } else {
+          LOG(WARNING) << "Failed to remove because: " << removeError.message
+            << "(" << removeError.code << ")\n";
+        }
       }
     }
     for (int i = 0; i < 9; i++) {

--- a/src/server/transducers/TransducerTest.cpp
+++ b/src/server/transducers/TransducerTest.cpp
@@ -31,7 +31,11 @@ TEST(TransducerTest, SumTest) {
       src,
       trIdentity(),
       intoReduction<double>([](double sum, int x) {
-        return sum + x;
+        std::cout << "gcc COMPILER BUG!"
+         " if this message is removed, the unit test "
+         " in " __FILE__ ":" <<  __LINE__ << " fails. Sum: "
+         << sum << "\n";
+        return sum + double(x);
       }, 1000));
   EXPECT_NEAR(result, 1000 + 21, 1.0e-6);
 }

--- a/src/shell_in_docker.sh
+++ b/src/shell_in_docker.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+"${DIR}/docker_run.sh" -it /bin/bash

--- a/src/third_party/CMakeLists.txt
+++ b/src/third_party/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_subdirectory("sqlite")
 add_subdirectory("NMEA2000/src")
-target_link_libraries(nmea2000 anemobox_millis)
+target_link_libraries(nmea2000 anemobox_Nmea2000Utils)


### PR DESCRIPTION
- Docker build image:
  - switch to gcc9
  - build in a mounted volume to avoid the 10GB docker limit
- add convenient scripts to work with docker
- fix a unit tests to work around a gcc bug
- properly disables the mongo unit test when mongo is not running